### PR TITLE
Remove MacOS specific link from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## Build Requirements
 
 You'll need Node.js and npm installed to build the documentation site. To install node, it is recommended to follow
-the guide provided by Node.js [here](https://nodejs.org/en/download/package-manager/#macos).
+the guide provided by Node.js [here](https://nodejs.org/en/download/package-manager).
 
 ## Building
 


### PR DESCRIPTION
Currently the README specifically points towards the MacOS section for installing Node.js.
I think it would be better to have a platform agnostic link.