### PR TITLE
Update ice connect step

### DIFF
--- a/pages/icerpc-core/ice-protocol/connection-establishment.md
+++ b/pages/icerpc-core/ice-protocol/connection-establishment.md
@@ -23,9 +23,9 @@ this connection.
 
 ```mermaid
 sequenceDiagram
-    Client->>Server: Open duplex connection
+    Client-)Server: Open duplex connection
     Note over Client,Server: Connect duplex connection
-    Server->>Client: ValidateConnection frame
+    Server--)Client: ValidateConnection frame
 ```
 
 ## ValidateConnection frame


### PR DESCRIPTION
This PR updates the language for the connect step, to make it clear that the ice protocol itself doesn't depend on TLS.