### PR TITLE
Formatting and readability improvements for service address page

### DIFF
--- a/pages/icerpc-core/invocation/service-address.md
+++ b/pages/icerpc-core/invocation/service-address.md
@@ -7,31 +7,28 @@ description: Understand the service address concept and syntax.
 
 A service address is a [URI][uri] that specifies the address of a service. It can be either absolute or relative.
 
-- **Relative Service Address:** An absolute path without query parameters or fragments.
-- **Absolute Service Address:** Uses the schemes `ice` or `icerpc` and contains the protocol required to reach the target
-  service.
+- **Absolute Service Address:** Contains the protocol, `ice` or `icerpc`, required to reach the target service.
   - The URI scheme identifies the protocol required to access the target service.
-  - An absolute service address may include one or more [server addresses](../connection/server-address), which establish
-    or locate a connection to a server hosting the service. The protocol of the server address matches that of the
-    enclosing service address.
+  - An absolute service address may include one or more [server addresses](../connection/server-address), which can be
+    used to establish or locate a connection to a server hosting the service. The protocol of the server address matches
+    that of the enclosing service address.
   - An absolute service address without a server address can have query parameters.
-
+- **Relative Service Address:** An absolute path that does not query parameters or fragments.
 
 {% callout %}
 
-An `ice` service address can have a fragment, which corresponds to an Ice facet representing a specific feature or
-aspect of the service.
+An `ice` service address can have a fragment; this fragment corresponds to an Ice facet.
 
 {% /callout %}
 
 The **path** of a service address allows the server to route requests to the desired service.
 
 In C#, the record class [`ServiceAddress`][service-address] provides a parsed and validated representation of a service
-address URI. It holds the same information as the original service address.
+address URI.
 
-## Categories of Service addresses
+## Categories of service addresses
 
-Service addresses can be categorized into four distinct types based on their characteristics and functionality.
+Service addresses can be categorized into four distinct types based on their syntax.
 
 ### Service address with a single server address
 
@@ -45,7 +42,7 @@ icerpc://host[:port]/<path>[?name=value][&name=value...][#fragment]
 The protocol (ice or icerpc), host, port and the query parameters specify the server address of the service address. The
 path and the optional fragment are properties of the service address itself.
 
-#### Example:
+#### Example
 
 ```
 icerpc://hello.zeroc.com/hello?transport=quic
@@ -57,9 +54,9 @@ server address to establish or reuse a connection to the target server and send 
 ### Service address with two or more server addresses
 
 A service address can specify additional server addresses with the `alt-server` query parameter. The value of this
-parameter is a server address without the `ice://` ori `icerpc://` prefix.
+parameter is a server address without the `ice://` or `icerpc://` prefix.
 
-#### Example:
+#### Example
 
 ```
 icerpc://hello.zeroc.com/hello?alt-server=bonjour.zeroc.com,hola.zeroc.com
@@ -70,7 +67,7 @@ typically used for fault tolerance.
 
 Each alt-server address can have its own query parameters.
 
-#### Example:
+#### Example
 
 ```
 icerpc://hello.zeroc.com/hello?transport=quic&alt-server=bonjour.zeroc.com?transport=tcp,hola.zeroc.com?transport=tcp
@@ -78,7 +75,7 @@ icerpc://hello.zeroc.com/hello?transport=quic&alt-server=bonjour.zeroc.com?trans
 
 If an alt-server address has multiple query parameters, it must use '$' instead of '&' to separate these parameters.
 
-#### Example:
+#### Example
 
 ```
 icerpc://hello.zeroc.com/hello?alt-server=bonjour.zeroc.com?transport=tcp$other=foo

--- a/pages/icerpc-core/invocation/service-address.md
+++ b/pages/icerpc-core/invocation/service-address.md
@@ -5,29 +5,35 @@ description: Understand the service address concept and syntax.
 
 ## Syntax
 
-A service address is a [URI][uri] that specifies the address of a service. It can be absolute or relative.
+A service address is a [URI][uri] that specifies the address of a service. It can be either absolute or relative.
 
-The scheme of an absolute service address is either ice or icerpc. A relative service address is an absolute path—query
-parameters and fragment are not allowed.
+- **Relative Service Address:** An absolute path without query parameters or fragments.
+- **Absolute Service Address:** Uses the schemes `ice` or `icerpc` and contains the protocol required to reach the target
+  service.
+  - The URI scheme identifies the protocol required to access the target service.
+  - An absolute service address may include one or more [server addresses](../connection/server-address), which establish
+    or locate a connection to a server hosting the service. The protocol of the server address matches that of the
+    enclosing service address.
+  - An absolute service address without a server address can have query parameters.
 
-The URI scheme of an absolute service address identifies the protocol to use to reach the target service.
 
-The path of a service address allows the server to route requests to the desired service.
+{% callout %}
 
-An absolute service address may include one or more [server addresses](../connection/server-address). These server
-addresses are used to establish or locate a connection to a server that hosts the service. The protocol of a server
-address is always the same as the protocol of the enclosing service address.
+An `ice` service address can have a fragment, which corresponds to an Ice facet representing a specific feature or
+aspect of the service.
 
-An absolute service address without a server address can have query parameters.
+{% /callout %}
 
-Finally, an ice service address can have a fragment; this fragment corresponds to an Ice facet.
+The **path** of a service address allows the server to route requests to the desired service.
 
-In C#, record class [`ServiceAddress`][service-address] is a parsed and validated representation of a service address
-URI: it holds exactly the same information.
+In C#, the record class [`ServiceAddress`][service-address] provides a parsed and validated representation of a service
+address URI. It holds the same information as the original service address.
 
-Service addresses can be divided in 4 categories:
+## Categories of Service addresses
 
-## Service address with a single server address
+Service addresses can be categorized into four distinct types based on their characteristics and functionality.
+
+### Service address with a single server address
 
 A service address with a single server address is very common:
 
@@ -39,7 +45,7 @@ icerpc://host[:port]/<path>[?name=value][&name=value...][#fragment]
 The protocol (ice or icerpc), host, port and the query parameters specify the server address of the service address. The
 path and the optional fragment are properties of the service address itself.
 
-For example:
+#### Example:
 
 ```
 icerpc://hello.zeroc.com/hello?transport=quic
@@ -51,7 +57,9 @@ server address to establish or reuse a connection to the target server and send 
 ### Service address with two or more server addresses
 
 A service address can specify additional server addresses with the `alt-server` query parameter. The value of this
-parameter is a server address without the `ice://` ori `icerpc://` prefix. For example:
+parameter is a server address without the `ice://` ori `icerpc://` prefix.
+
+#### Example:
 
 ```
 icerpc://hello.zeroc.com/hello?alt-server=bonjour.zeroc.com,hola.zeroc.com
@@ -60,20 +68,23 @@ icerpc://hello.zeroc.com/hello?alt-server=bonjour.zeroc.com,hola.zeroc.com
 `alt-server` means the application can find the service in the first server or in any of these alternate servers. It's
 typically used for fault tolerance.
 
-Each alt-server address can have its own query parameters. For example:
+Each alt-server address can have its own query parameters.
+
+#### Example:
 
 ```
 icerpc://hello.zeroc.com/hello?transport=quic&alt-server=bonjour.zeroc.com?transport=tcp,hola.zeroc.com?transport=tcp
 ```
 
 If an alt-server address has multiple query parameters, it must use '$' instead of '&' to separate these parameters.
-For example:
+
+#### Example:
 
 ```
 icerpc://hello.zeroc.com/hello?alt-server=bonjour.zeroc.com?transport=tcp$other=foo
 ```
 
-## Absolute service address with no server address
+### Absolute service address with no server address
 
 An absolute service address with no host does not specify a server address. Its syntax is:
 
@@ -82,7 +93,9 @@ icerpc:/path[?name=value][&name=value...]
 ice:/path[?name=value][&name=value...][#fragment]
 ```
 
-Here, the query parameters are properties of the service address itself. For example:
+Here, the query parameters are properties of the service address itself.
+
+#### Example:
 
 ```
 icerpc:/greeter
@@ -92,7 +105,7 @@ ice:/greeter?adapter-id=greeter-union
 A server address-less service address is often used with a `ClientConnection`. Since a client connection is bound to a
 single server address, there is no need to repeat the server address when making an invocation with such a connection.
 
-For example:
+#### Example:
 
 ```csharp
 // connects to icerpc://hello.zeroc.com
@@ -105,7 +118,7 @@ using var request = new OutgoingRequest(new ServiceAddress(new Uri("icerpc:/gree
 IncomingResponse response = await connection.InvokeAsync(request);
 ```
 
-## Relative service address
+### Relative service address
 
 A relative service address consists of an absolute path. The IceRPC core does not consume relative service addresses;
 in particular, it's an error to create an outgoing request with a relative service address.

--- a/pages/icerpc-core/invocation/service-address.md
+++ b/pages/icerpc-core/invocation/service-address.md
@@ -7,13 +7,16 @@ description: Understand the service address concept and syntax.
 
 A service address is a [URI][uri] that specifies the address of a service. It can be either absolute or relative.
 
-- **Absolute Service Address:** Contains the protocol, `ice` or `icerpc`, required to reach the target service.
-  - The URI scheme identifies the protocol required to access the target service.
-  - An absolute service address may include one or more [server addresses](../connection/server-address), which can be
+- **Absolute Service Address:** Specifies a full path, including the protocol (`ice` or `icerpc`) to access the target
+  service.
+  - The protocol, identified by the URI scheme, is required to reach the target service.
+  - Absolute service addresses can contain one or more [server addresses](../connection/server-address), which can be
     used to establish or locate a connection to a server hosting the service. The protocol of the server address matches
     that of the enclosing service address.
-  - An absolute service address without a server address can have query parameters.
-- **Relative Service Address:** An absolute path that does not query parameters or fragments.
+  - An absolute service address without a server address may include query parameters.
+- **Relative Service Address:** An absolute path.
+  - Query parameters are disallowed.
+  - Fragments are disallowed.
 
 {% callout %}
 


### PR DESCRIPTION
This PR makes some minor changes to improve the service address page. Previously the syntax section was just one big paragraph that made it hard to see the differences between relative and absolute services addresses.