### PR TITLE
Rename introduction -> index.md

### DIFF
--- a/data/icerpc-core-data.ts
+++ b/data/icerpc-core-data.ts
@@ -158,8 +158,8 @@ export const rpcCoreData: SideBarSourceType[] = [
     title: 'The Slic protocol',
     links: [
       {
-        title: 'Introduction',
-        path: `${RPC_CORE_BASE_URL}/slic-protocol/introduction`
+        title: 'Overview',
+        path: `${RPC_CORE_BASE_URL}/slic-protocol/`
       },
       {
         title: 'Connection establishment',

--- a/pages/getting-started/raising-the-bar/modular-rpc-for-quic.md
+++ b/pages/getting-started/raising-the-bar/modular-rpc-for-quic.md
@@ -108,4 +108,4 @@ multiplexed transport and then plug it in IceRPC. All the transport interfaces a
 [http3]: https://en.wikipedia.org/wiki/HTTP/3
 [iap]: https://en.wikipedia.org/wiki/List_of_Bluetooth_profiles#iPod_Accessory_Protocol_(iAP)
 [quic]: https://en.wikipedia.org/wiki/QUIC
-[slic]: ../../icerpc-core/slic-protocol/introduction
+[slic]: ../../icerpc-core/slic-protocol

--- a/pages/icerpc-core/slic-protocol/index.md
+++ b/pages/icerpc-core/slic-protocol/index.md
@@ -1,10 +1,7 @@
 ---
-title: Introduction
-description: The Slic multiplexed transport protocol.
+title: The Slic multiplexed transport protocol
 show_toc: false
 ---
-
-## The Slic transport protocol
 
 Slic is a transport protocol designed to provide the same functionality as [QUIC][quic]. Instead of relying on UDP, it
 relies on a duplex transport (such as TCP) for the data transmission.


### PR DESCRIPTION
This PR renames the introduction page to index.md.

See also #126.