### PR TITLE
Minor Cookie & Link Fixes.

### DIFF
--- a/components/Cookies.tsx
+++ b/components/Cookies.tsx
@@ -135,7 +135,7 @@ export function CookiesBanner() {
               className="flex-1 px-4 py-3 text-gray-500 duration-150 hover:bg-green-400 hover:text-white"
               onClick={handleAccept}
             >
-              Of course
+              Accept
             </button>
           </div>
         </motion.div>

--- a/components/Shell/TableOfContents.tsx
+++ b/components/Shell/TableOfContents.tsx
@@ -80,8 +80,8 @@ export const TableOfContents = ({ toc }: { toc: TOCItem[] }) => {
         >
           <MoreItem
             href={
-              'https://github.com/zeroc-ice/icerpc-docs/tree/main/pages' +
-              currentPath
+              'https://github.com/icerpc/icerpc-docs/tree/main/pages' +
+              currentPath.replace(/^\/slice\d/, '/slice')
             }
           >
             <FontAwesomeIcon

--- a/components/Shell/TopNavigation/TopNav.tsx
+++ b/components/Shell/TopNavigation/TopNav.tsx
@@ -72,7 +72,7 @@ export const TopNav = () => {
               <ThemeToggle />
               <a
                 className="flex h-full items-center justify-center p-4 hover:text-primary dark:text-[rgba(255,255,255,0.8)] "
-                href="https://github.com/zeroc-ice"
+                href="https://github.com/icerpc"
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="Github"


### PR DESCRIPTION
This PR fixes #149, #150, and #151.
I didn't realize they would be so easy to fix or I wouldn't of even bothered opening issues for them.

- Now the text of the cookies popup matches the text of the button (both say "Accept")
- Now clicking the GitHub icon takes you to IceRPCs GitHub page (instead of ZeroC-Ice's page)
- The "Edit this page" button now points to the correct URL for Slice pages.