### PR TITLE
Removed references to stream control frames, fixes #156

### DIFF
--- a/pages/icerpc/slic-transport/streams.md
+++ b/pages/icerpc/slic-transport/streams.md
@@ -36,9 +36,8 @@ the sending of other stream frames or connection frames.
 
 ## Stream creation
 
-Stream creation is initiated by the sending of the first [Stream][stream-frame] or [StreamLast][stream-last-frame] frame
-with a newly allocated stream identifier. Sending another stream frame with a newly allocated stream identifier is a
-protocol error.
+Sending a [Stream][stream-frame] or [StreamLast][stream-last-frame] frame with a newly allocated stream identifier
+creates the stream. Sending another stream frame with a newly allocated stream identifier is a protocol error.
 
 The peer accepts a new stream when it receives a Stream or StreamLast frame with a stream identifier larger than the
 last accepted stream identifier.
@@ -52,13 +51,13 @@ be 4.
 Each side of a stream maintains a reads and writes closed state. When the application is done sending data on a stream,
 it closes writes on the stream. When it's done reading data, it closes reads.
 
-The update of the closed state must trigger the sending of one of the following frame:
+The update of the closed state triggers the sending of one of the following frames:
 
-- When reads are closed, the transport implementation must send a [StreamReadsClosed][stream-reads-closed-frame] frame.
-  Upon receiving this frame, the peer must stop sending data over the stream and close the stream writes.
+- Slic sends a [StreamWritesClosed][stream-writes-closed-frame] frame to the peer when the application closes writes on
+  the stream. Upon receiving this frame, the peer must stop reading data from the stream and close the stream reads.
 
-- When writes are closed, the transport implementation must send a [StreamWritesClosed][stream-writes-closed-frame]
-  frame. Upon receiving this frame, the peer must stop reading data from the stream and close the stream reads.
+- Slic sends a [StreamReadsClosed][stream-reads-closed-frame] frame to the peer when the application closes writes on
+  the stream. Upon receiving this frame, the peer must stop sending data over the stream and close the stream writes.
 
 A stream is considered closed when both writes and reads are closed.
 


### PR DESCRIPTION
This PR removes references to stream control frames (and wraps few lines on 120 columns).