### PR TITLE
Moved validate/close connection frames documentation

### DIFF
--- a/pages/icerpc/ice-protocol/connection-establishment.md
+++ b/pages/icerpc/ice-protocol/connection-establishment.md
@@ -14,8 +14,9 @@ An ice client connects to an ice server as follows:
 3. Both the client and the server "connect" the duplex connection. This connect operation is transport-dependent: it's
 no-op for a plain TCP connection and it corresponds to the TLS handshake for a TCP+TLS connection.
 
-4. The server sends a `ValidateConnection` frame to the client. As soon as the server sends this frame, it considers the
-connection established and can start accepting incoming requests and sending outgoing requests on this connection.
+4. The server sends a [ValidateConnection][validateconnection-frame] frame to the client. As soon as the server sends
+this frame, it considers the connection established and can start accepting incoming requests and sending outgoing
+requests on this connection.
 
 5. The client waits until it receives a `ValidateConnection` frame from the server. When the client receives this frame,
 it considers the connection established and can start sending outgoing requests and accepting incoming requests on
@@ -29,11 +30,4 @@ sequenceDiagram
     Server-)Client: ValidateConnection frame
 ```
 
-## ValidateConnection frame
-
-The `ValidateConnection` frame is an ice protocol frame with type `ValidateConnection`. Its body is empty. The
-server-side of an ice connection sends this frame to the client-side during connection establishment (see above).
-
-This frame is also used for heartbeats: once the connection is established, the client or the server can send a
-`ValidateConnection` frame to its peer, and the peer will receive and ignore this frame. A heartbeat corresponds to one
-`ValidateConnection` frame.
+[validateconnection-frame]: protocol-frames#validateconnection-frame

--- a/pages/icerpc/ice-protocol/connection-shutdown.md
+++ b/pages/icerpc/ice-protocol/connection-shutdown.md
@@ -16,9 +16,9 @@ A client or a server follows these steps when it wants to shutdown an ice connec
 
 2. Wait for all (local) invocations and dispatches to complete.
 
-3. Stop sending [heartbeats](connection-establishment#validateconnection-frame) to the peer.
+3. Stop sending [heartbeats][validateconnection-frame] to the peer.
 
-4. Send a [`CloseConnection`](#closeconnection-frame) frame to the peer.\
+4. Send a [CloseConnection][closeconnection-frame] frame to the peer.\
 The client or server skips this step if it already received a `CloseConnection` frame from the peer.
 
 5. Wait for a `CloseConnection` frame from the peer or for the peer to close the duplex connection.\
@@ -34,7 +34,5 @@ sequenceDiagram
     Server-->>Client: Close duplex connection
 ```
 
-## CloseConnection frame
-
-The `CloseConnection` frame is an ice protocol frame with type `CloseConnection`. Its body is empty. A client or server
-must not send any additional frame after sending a `CloseConnection` frame.
+[closeconnection-frame]: protocol-frames#closeconnection-frame
+[validateconnection-frame]: protocol-frames#validateconnection-frame

--- a/pages/icerpc/ice-protocol/protocol-frames.md
+++ b/pages/icerpc/ice-protocol/protocol-frames.md
@@ -53,6 +53,20 @@ The `compressionStatus` field is not used or supported by IceRPC. It must be set
 
 The `frameSize` represents the total number of bytes in the frame, including the frame header.
 
+## CloseConnection frame
+
+The `CloseConnection` frame is an ice protocol frame with type `CloseConnection`. Its body is empty. A client or server
+must not send any additional frame after sending a `CloseConnection` frame.
+
+## ValidateConnection frame
+
+The `ValidateConnection` frame is an ice protocol frame with type `ValidateConnection`. Its body is empty. The
+server-side of an ice connection sends this frame to the client-side during [connection establishment][connection-establishment].
+
+This frame is also used for heartbeats: once the connection is established, the client or the server can send a
+`ValidateConnection` frame to its peer, and the peer will receive and ignore this frame. A heartbeat corresponds to one
+`ValidateConnection` frame.
+
 ## Request frame
 
 A request frame carries an ice request. It consists of a header with the `Request` type followed by a `RequestData`
@@ -219,3 +233,4 @@ For the same reason, when IceRPC receives an encapsulation, it makes sure the en
 set to 1.1.
 
 [protocol-and-encoding]: https://doc.zeroc.com/ice/3.7/ice-protocol-and-encoding
+[connection-establishment]: connection-establishment


### PR DESCRIPTION
This PR moves the documentation of the validate/close connection frames to the protocol-frames page and adds like to these frame where needed. Fixes #210.
