### PR TITLE
Replace "bundled with" with "provided by"

### DIFF
--- a/pages/icerpc/dependency-injection/dispatch-pipeline-with-di.md
+++ b/pages/icerpc/dependency-injection/dispatch-pipeline-with-di.md
@@ -62,7 +62,7 @@ to downstream dispatchers using an [IServiceProviderFeature].
 A standard middleware is a middleware that can be used with or without a DI container: it does not rely on a DI
 container injecting services to operate, and it implements interface `IDispatcher`.
 
-All of IceRPC's built-in middleware are standard middleware: you can use them with or without DI, and they use
+All the middleware that ship with IceRPC are standard middleware: you can use them with or without DI, and they use
 features for communications within a dispatch.
 
 These middleware can be installed in a [Router] or an [IDispatcherBuilder]. For

--- a/pages/icerpc/dependency-injection/invocation-pipeline-with-di.md
+++ b/pages/icerpc/dependency-injection/invocation-pipeline-with-di.md
@@ -39,9 +39,9 @@ You must specify a final invoker with the `Into` method. With this example, the 
 
 ## Installing an interceptor in an IInvokerBuilder
 
-All of IceRPC's built-in interceptors can be used with or without DI, and use [features] for communications within an
-invocation. For instance, the retry interceptor communicates with a connection cache using an [IServerAddressFeature] to
-coordinate retries over replicated servers.
+All the interceptors that ship with IceRPC can be used with or without DI, and use [features] for communications within
+an invocation. For instance, the retry interceptor communicates with a connection cache using an [IServerAddressFeature]
+to coordinate retries over replicated servers.
 
 These interceptors can be installed into a [Pipeline] or an [IInvokerBuilder].
 


### PR DESCRIPTION
I think is more correct to talk about middleware/interceptors provided by IceRPC, "bundled with" sounds like something is not modular which is not the case here.