### PR TITLE
Added Attribute Highlighting to Slice Highlighter

### DIFF
--- a/utils/prism-slice.js
+++ b/utils/prism-slice.js
@@ -25,6 +25,21 @@
                 greedy: true
             }
         ],
+        attribute: {
+            pattern: /\[+[^\]\r\n]*\]+/,
+            inside: {
+                arguments: {
+                    pattern: /(?<=\()[^\)\r\n]*(?=\))/,
+                    inside: {
+                        string: /\"(?:\\.|[^\\\"\r\n])*?\"/,
+                        constant: /\b\w+\b/,
+                        punctuation: /,/
+                    }
+                },
+                function: /[\w:]+/,
+                punctuation: /[\[\]()]/,
+            }
+        },
         string: /\"(?:\\.|[^\\\"\r\n])*?\"/,
         keyword: /\b(module|struct|exception|class|interface|enum|custom|typealias|compact|idempotent|mode|stream|tag|throws|unchecked)\b/,
         builtin: [


### PR DESCRIPTION
This PR adds syntax highlighting for attributes:
![image](https://github.com/icerpc/icerpc-docs/assets/25963603/e848c648-195a-4f97-89cb-e5105d530bd7)
![image](https://github.com/icerpc/icerpc-docs/assets/25963603/ed8a6dd9-97df-48fb-936b-c315ed361333)
As part of #231.