### PR TITLE
Move preprocessor to language guide

### DIFF
--- a/data/slice-1-data.ts
+++ b/data/slice-1-data.ts
@@ -106,6 +106,10 @@ export const slice1Data: SideBarSourceType[] = [
       {
         title: 'Doc comments',
         path: `${SLICE1_BASE_URL}/language-guide/doc-comments`
+      },
+      {
+        title: 'Preprocessor directives',
+        path: `${SLICE1_BASE_URL}/language-guide/preprocessor-directives`
       }
     ]
   },
@@ -119,10 +123,6 @@ export const slice1Data: SideBarSourceType[] = [
       {
         title: 'Grammar specification',
         path: `${SLICE1_BASE_URL}/language-reference/grammar`,
-      },
-      {
-        title: 'Preprocessor directives',
-        path: `${SLICE1_BASE_URL}/language-reference/preprocessor-directives`
       },
       {
         title: 'Keywords',

--- a/data/slice-2-data.ts
+++ b/data/slice-2-data.ts
@@ -98,6 +98,10 @@ export const slice2Data: SideBarSourceType[] = [
       {
         title: 'Doc comments',
         path: `${SLICE2_BASE_URL}/language-guide/doc-comments`
+      },
+      {
+        title: 'Preprocessor directives',
+        path: `${SLICE2_BASE_URL}/language-guide/preprocessor-directives`
       }
     ]
   },
@@ -111,10 +115,6 @@ export const slice2Data: SideBarSourceType[] = [
       {
         title: 'Grammar specification',
         path: `${SLICE2_BASE_URL}/language-reference/grammar`,
-      },
-      {
-        title: 'Preprocessor directives',
-        path: `${SLICE2_BASE_URL}/language-reference/preprocessor-directives`
       },
       {
         title: 'Keywords',

--- a/pages/slice/language-guide/preprocessor-directives.md
+++ b/pages/slice/language-guide/preprocessor-directives.md
@@ -9,7 +9,7 @@ code one line at a time.
 
 ## Symbols
 
-Preprocessor symbols are [identifiers](./lexical-rules#identifiers) that can be defined and undefined by the
+Preprocessor symbols are identifiers that can be defined and undefined by the
 preprocessor. Unlike C/C++, preprocessor symbols can not be assigned a value. Instead, preprocessor symbols are either
 defined or undefined.
 


### PR DESCRIPTION
This PR moves the current preprocessor directives page from the Language reference to language guide. It's a better fit as a guide page, like the corresponding doc page that we already have. 

A future PR will split the grammar specification page into it's multiple pages, including a new technical  preprocessor page based off of these contents.