### PR TITLE
Simple overview page for getting started

### DIFF
--- a/pages/getting-started/index.md
+++ b/pages/getting-started/index.md
@@ -7,16 +7,8 @@ showReadingTime: false
 Welcome to the IceRPC Getting Started guide. This guide is designed to get you up and running with IceRPC as quickly as
 possible.
 
-{% divider /%}
-
-#### Currently supported languages
-
-- [C#](/getting-started/quickstart)
-
-#### Future languages
-
-- Rust
-- More to come!
+Currently, IceRPC supports C#. We have plans to add support for Rust as the next language. Stay tuned for more
+information about upcoming Rust support and other planned future languages.
 
 ## Quick links
 


### PR DESCRIPTION
Closes https://github.com/icerpc/icerpc-docs/issues/287
Closes https://github.com/icerpc/icerpc-docs/issues/243

This PR updates the getting started overview page now that all of the content has changed. I considered getting rid of it entirely and just having the quickstart be the first page but @externl brought up a good point that it is useful for navigating to thinks quickly especially on mobile where the side navigation is collapsed.

