### PR TITLE
Remove Language Reference

### DIFF
--- a/data/slice-1-data.ts
+++ b/data/slice-1-data.ts
@@ -114,27 +114,6 @@ export const slice1Data: SideBarSourceType[] = [
     ]
   },
   {
-    title: 'Language reference',
-    links: [
-      {
-        title: 'Overview',
-        path: `${SLICE1_BASE_URL}/language-reference/`
-      },
-      {
-        title: 'Slice grammar',
-        path: `${SLICE1_BASE_URL}/language-reference/slice-grammar`
-      },
-      {
-        title: 'Doc comments',
-        path: `${SLICE1_BASE_URL}/language-reference/doc-comments`
-      },
-      {
-        title: 'Preprocessor directives',
-        path: `${SLICE1_BASE_URL}/language-reference/preprocessor-directives`
-      }
-    ]
-  },
-  {
     title: 'Encoding reference',
     links: [
       {

--- a/data/slice-2-data.ts
+++ b/data/slice-2-data.ts
@@ -106,27 +106,6 @@ export const slice2Data: SideBarSourceType[] = [
     ]
   },
   {
-    title: 'Language reference',
-    links: [
-      {
-        title: 'Overview',
-        path: `${SLICE2_BASE_URL}/language-reference/`
-      },
-      {
-        title: 'Slice grammar',
-        path: `${SLICE2_BASE_URL}/language-reference/slice-grammar`
-      },
-      {
-        title: 'Doc comments',
-        path: `${SLICE2_BASE_URL}/language-reference/doc-comments`
-      },
-      {
-        title: 'Preprocessor directives',
-        path: `${SLICE2_BASE_URL}/language-reference/preprocessor-directives`
-      }
-    ]
-  },
-  {
     title: 'Encoding reference',
     links: [
       {


### PR DESCRIPTION
In the interest of shipping, this PR removes the Slice language reference. We can add it back one it's been better refined.
But I feel time is better spent adding back the doc-comments documentation, and reviewing the other doc pages.