### PR TITLE
Update 'ice' syntax highlighter.

### DIFF
--- a/utils/prism-ice.js
+++ b/utils/prism-ice.js
@@ -1,46 +1,47 @@
 (function (Prism) {
-    Prism.languages.ice = Prism.languages.extend('clike', {
-
-        'keyword': /\b(?:const|extends|idempotent|implements|local|optional|out|throws)\b/,
-        'builtin': /\b(?:bool|byte|class|dictionary|double|enum|exception|float|int|interface|long|module|sequence|short|string|struct|void|LocalObject|Object)\b/,
-        'number': [
-            // binary and octal integers
-            /\b0(?:b[01_]+|o[0-7_]+)i?\b/i,
-            // hexadecimal integers and floats
-            /\b0x(?:[a-f\d_]+(?:\.[a-f\d_]*)?|\.[a-f\d_]+)(?:p[+-]?\d+(?:_\d+)*)?i?(?!\w)/i,
-            // decimal integers and floats
-            /(?:\b\d[\d_]*(?:\.[\d_]*)?|\B\.\d[\d_]*)(?:e[+-]?[\d_]+)?i?(?!\w)/i
-        ],
-        'preprocessor': {
-            pattern: /^ *#.*/gm,
-            greedy: true,
-        },
-        'class-name': {
-            pattern: /(\b(?:enum|interface|struct|class|exception|module|extends)\s+|\bcatch\s+\()[\w.\\]+/i,
-            lookbehind: true
-        },
-    });
-
-    Prism.languages.insertBefore('ice', 'keyword', {
-        'preprocessor': {
-            pattern: /(^[\t ]*)#.*/m,
-            lookbehind: true,
+    Prism.languages.ice = {
+        preprocessor: {
+            pattern: /(?<=\n|^)[^\S\r\n]*#\s*[a-zA-Z]+/,
             inside: {
-                'string': [
-                    {
-                        // highlight the path of the include statement as a string
-                        pattern: /^(#\s*include\s*)<[^>]+>/,
-                        lookbehind: true
-                    },
-                    Prism.languages.clike['string']
-                ],
-                'directive': {
-                    pattern: /^(#\s*)[a-z]+/,
-                    lookbehind: true,
-                    alias: 'keyword'
-                },
-                'directive-hash': /^#/,
+                "class-name": /#\s*[a-zA-Z]+/,
             }
-        }
-    });
+        },
+        comment: [
+            {
+                // Doc comments
+                pattern: /\/\/\/.*|\/\*\*[\s\S]*?(?:\*\/)/,
+                greedy: true,
+                inside: {
+                    tag: /@[a-z]+\b/,
+                    punctuation: /::|[:{}]/
+                }
+            },
+            {
+                // Non-doc comments
+                pattern: /\/\/.*|\/\*[\s\S]*?(?:\*\/)/,
+                greedy: true
+            }
+        ],
+        attribute: {
+            pattern: /\[+(([a-zA-Z0-9:-]*|\"(?:\\.|[^\\\"\r\n])*?\")(,|\s)*)*\]+/,
+            inside: {
+                function: /[a-zA-Z0-9:-]+|\"(?:\\.|[^\\\"\r\n])*?\"/,
+                punctuation: /[\[\],]/
+            }
+        },
+        string: /\"(?:\\.|[^\\\"\r\n])*?\"/,
+        keyword: /\b(module|class|struct|exception|enum|interface|sequence|dictionary|const|optional|idempotent|out|local|extends|implements|throws)\b/,
+        builtin: [
+            {
+                pattern: /\b(bool|byte|short|int|long|float|double|string|void|Value|Object|LocalObject)\b/,
+                alias: 'keyword'
+            },
+            {
+                pattern: /\b(true|false)\b/,
+                alias: 'constant'
+            }
+        ],
+        number: /\b[0-9](\w|\.)*\b/,
+        punctuation: /(::|[(){}<>:;,=+-])/
+    };
 }(Prism));

--- a/utils/prism-slice.js
+++ b/utils/prism-slice.js
@@ -3,7 +3,7 @@
         preprocessor: {
             pattern: /(?<=\n|^)[^\S\r\n]*#[^\r\n\/]*/,
             inside: {
-                keyword: /#\s*(define|undef|if|elif|else|endif)\b/,
+                "class-name": /#\s*(define|undef|if|elif|else|endif)\b/,
                 symbol: /\b\w+\b/,
                 operator: /\!|&&|\|\|/,
                 punctuation: /[#()]/
@@ -53,6 +53,6 @@
             }
         ],
         number: /\b[0-9]\w*\b/,
-        punctuation: /(->|::|\[\[|\]\]|[(){}<>\[\]:,=?-])/
+        punctuation: /(->|::|[(){}<>:,=?-])/
     };
 }(Prism));


### PR DESCRIPTION
This PR implements #231 and brings the Ice and Slice syntax highlighters into parity with one another.
It also dramatically simplifies the Ice syntax highlighter's regular expressions.
![image](https://github.com/icerpc/icerpc-docs/assets/25963603/bf325ab1-096a-4c6e-8153-ed1b95b015b1)
![image](https://github.com/icerpc/icerpc-docs/assets/25963603/6e235773-855d-49de-8f41-7a8966cf7947)
I find the colors in Dark mode a little much. In the future, we might want to tweak our highlighter colors.