### PR TITLE
Fixes #308

### DIFF
--- a/components/Tags/Examples.tsx
+++ b/components/Tags/Examples.tsx
@@ -38,7 +38,7 @@ const ExampleCard = ({ title, description, href }: ExampleCardProps) => (
     className="flex flex-col justify-between rounded-xl border bg-white p-6 shadow-sm dark:border-darkBorder dark:bg-black"
   >
     <div className="relative flex h-6 w-6 items-center justify-center rounded-full ">
-      <FontAwesomeIcon icon={faGithub} />
+      <FontAwesomeIcon icon={faGithub} className="h-6 w-6" />
     </div>
     <div className="mt-8 flex flex-col justify-between">
       <h3 className="my-0 text-[16px] font-semibold">{title}</h3>


### PR DESCRIPTION
This PR fixes the issue with the GitHub icon didn't show up on macOS. I added "w-6 h-6" to the class param. It's the same value as the parent div but I'm not 100% sure it's correct. The navbar GitHub icon uses "w-5 h-5". Let me know if this needs fixing.