### PR TITLE
Cleanup the README.md and add WRITING_DOCS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ install node, it is recommended to follow the guide provided by Node.js
 
 ## Writing Documentation
 
-For comprehensive guidelines on documentation writing, including how to use custom nodes and tags, please refer to the
+For comprehensive guidelines on writing documentation, including how to use custom nodes and tags, please refer to the
 [Writing Documentation](/WRITING_DOCS.md) page.

--- a/WRITING_DOCS.md
+++ b/WRITING_DOCS.md
@@ -272,7 +272,7 @@ a title, description, and link.
 
 #### Examples
 
-See the [`grid`](#grid) tag for an example of how to use the `mini-card` tag
+See the [`grid`](#grid) tag for an example of how to use the `mini-card` tag.
 
 ### Light-Mode
 


### PR DESCRIPTION
Closes #317 

This PR cleans up the main README.md a bit and moves all of the content about how to write docs to its own file `WRITING_DOCS.md`. In the future this writing docs file should probably be cleaned up more but its not a high priority.