### PR TITLE
Simplified Regular Expressions

### DIFF
--- a/utils/prism-ebnf.js
+++ b/utils/prism-ebnf.js
@@ -12,11 +12,7 @@
         },
         definition: [
             {
-                pattern: /\b[a-zA-Z]\w*(?=(<\w*>)?\s*:)/,
-                alias: ['rule', 'class-name']
-            },
-            {
-                pattern: /(?<=\n)[a-zA-Z]\w*(?=(<\w*>)?\s*;)/,
+                pattern: /\b[a-zA-Z]\w*(?=(<\w*>)?\s*[:;])/,
                 alias: ['rule', 'class-name']
             }
         ],

--- a/utils/prism-ice.js
+++ b/utils/prism-ice.js
@@ -1,7 +1,7 @@
 (function (Prism) {
     Prism.languages.ice = {
         preprocessor: {
-            pattern: /(?<=\n|^)[^\S\r\n]*#\s*[a-zA-Z]+/,
+            pattern: /#\s*[a-zA-Z]+/,
             inside: {
                 "class-name": /#\s*[a-zA-Z]+/,
             }

--- a/utils/prism-slice.js
+++ b/utils/prism-slice.js
@@ -1,7 +1,7 @@
 (function (Prism) {
     Prism.languages.slice = {
         preprocessor: {
-            pattern: /(?<=\n|^)[^\S\r\n]*#[^\r\n\/]*/,
+            pattern: /#[^\r\n\/]*/,
             inside: {
                 "class-name": /#\s*(define|undef|if|elif|else|endif)\b/,
                 symbol: /\b\w+\b/,
@@ -29,11 +29,11 @@
             pattern: /\[+[^\]\r\n]*\]+/,
             inside: {
                 arguments: {
-                    pattern: /(?<=\()[^\)\r\n]*(?=\))/,
+                    pattern: /\([^\)\r\n]*\)/,
                     inside: {
                         string: /\"(?:\\.|[^\\\"\r\n])*?\"/,
                         constant: /\b\w+\b/,
-                        punctuation: /,/
+                        punctuation: /[,()]/
                     }
                 },
                 function: /[\w:]+/,


### PR DESCRIPTION
This PR simplifies the regular expressions used for syntax highlighting.
Specifically it removes lookbehinds, since these aren't supported by older versions of Safari.