### PR TITLE
Added documentation for compact type IDs

### DIFF
--- a/pages/slice/language-guide/class-types.md
+++ b/pages/slice/language-guide/class-types.md
@@ -187,10 +187,9 @@ However, to reduce overhead, you can assign a numeric type ID to a class instead
 
 ```slice
 module Foo
-{
-    class ClassA {}     // has a type ID of "::Foo::ClassA"
-    class ClassB(9) {}  // has a compact type ID of `9`
-}
+
+class ClassA {}     // has a type ID of "::Foo::ClassA"
+class ClassB(9) {}  // has a compact type ID of `9` in addition to a type ID of "::Foo::ClassB"
 ```
 
 These compact type IDs must be non-negative and unique across your application.

--- a/pages/slice/language-guide/class-types.md
+++ b/pages/slice/language-guide/class-types.md
@@ -178,6 +178,22 @@ When the generated code decodes a class in sliced format and slices off derived 
 slices: it keeps them in the decoded instance. If you later send this class instance to another application that knows
 the derived class type, this application will decode successfully the full type.
 
+## Compact type IDs
+
+When the generated code encodes a class it needs a way to transmit the class's type.
+It does this by encoding the class's _type ID_ - a special value that is unique to each class.
+Normally, this is the class's fully-qualified identifier, which gets encoded as a string.
+However, to reduce overhead, Slice allows you to assign a numeric type ID to a class instead. For example:
+
+```slice
+class ClassWithStringTypeId {}     // has a type-id of "ClassWithStringTypeId"
+class ClassWithNumericTypeId(9) {} // has a type-id of `9`
+```
+
+Compact type IDs have no effect on the mapping of a class, or the contract for using it.
+It only affects how the class is encoded and decoded.
+For more information on how classes are encoded, click [here][class-encoding].
+
 ## C# mapping
 
 A Slice class maps to a public C# class with the same name. If the Slice class has no base class, the mapped class
@@ -254,3 +270,4 @@ public partial class RearBumper : CarPart
 [format-metadata]: https://doc.zeroc.com/ice/3.7/the-slice-language/slice-metadata-directives#id-.SliceMetadataDirectivesv3.7-format
 [tagged-fields]: fields#tagged-fields
 [SliceClass]: csharp:ZeroC.Slice.SliceClass
+[class-encoding]: /slice1/encoding/user-defined-types#class

--- a/pages/slice/language-guide/class-types.md
+++ b/pages/slice/language-guide/class-types.md
@@ -186,10 +186,10 @@ Normally, this is the class's fully-qualified identifier.
 However, to reduce overhead, you can assign a numeric type ID to a class instead. For example:
 
 ```slice
-module MyModule
+module Foo
 {
-    class ClassWithStringTypeId {}     // has a type ID of "MyModule::ClassWithStringTypeId"
-    class ClassWithNumericTypeId(9) {} // has a type ID of `9`
+    class ClassA {}     // has a type ID of "::Foo::ClassA"
+    class ClassB(9) {}  // has a type ID of `9`
 }
 ```
 

--- a/pages/slice/language-guide/class-types.md
+++ b/pages/slice/language-guide/class-types.md
@@ -189,11 +189,11 @@ However, to reduce overhead, you can assign a numeric type ID to a class instead
 module Foo
 {
     class ClassA {}     // has a type ID of "::Foo::ClassA"
-    class ClassB(9) {}  // has a type ID of `9`
+    class ClassB(9) {}  // has a compact type ID of `9`
 }
 ```
 
-These _compact_ type IDs must be non-negative and unique across your application.
+These compact type IDs must be non-negative and unique across your application.
 They affect only the encoding of classes, not their mapping.
 Refer to the [Ice Manual][compact-type-ids] to learn more.
 

--- a/pages/slice/language-guide/class-types.md
+++ b/pages/slice/language-guide/class-types.md
@@ -180,19 +180,22 @@ the derived class type, this application will decode successfully the full type.
 
 ## Compact type IDs
 
-When the generated code encodes a class it needs a way to transmit the class's type.
-It does this by encoding the class's _type ID_ - a special value that is unique to each class.
-Normally, this is the class's fully-qualified identifier, which gets encoded as a string.
-However, to reduce overhead, Slice allows you to assign a numeric type ID to a class instead. For example:
+When the generated code encodes a class it needs to transmit the class's type.
+It does this by encoding the class's _type ID_ - a unique value associated with each class.
+Normally, this is the class's fully-qualified identifier.
+However, to reduce overhead, you can assign a numeric type ID to a class instead. For example:
 
 ```slice
-class ClassWithStringTypeId {}     // has a type ID of "ClassWithStringTypeId"
-class ClassWithNumericTypeId(9) {} // has a type ID of `9`
+module MyModule
+{
+    class ClassWithStringTypeId {}     // has a type ID of "MyModule::ClassWithStringTypeId"
+    class ClassWithNumericTypeId(9) {} // has a type ID of `9`
+}
 ```
 
-Compact type IDs have no effect on the mapping of a class, or the contract for using it.
-It only affects how the class is encoded and decoded.
-For more information on how classes are encoded, click [here][class-encoding].
+These _compact_ type IDs must be non-negative and unique across your application.
+They affect only the encoding of classes, not their mapping.
+Refer to the [Ice Manual][compact-type-ids] to learn more.
 
 ## C# mapping
 
@@ -270,4 +273,4 @@ public partial class RearBumper : CarPart
 [format-metadata]: https://doc.zeroc.com/ice/3.7/the-slice-language/slice-metadata-directives#id-.SliceMetadataDirectivesv3.7-format
 [tagged-fields]: fields#tagged-fields
 [SliceClass]: csharp:ZeroC.Slice.SliceClass
-[class-encoding]: /slice1/encoding/user-defined-types#class
+[compact-type-ids]: https://doc.zeroc.com/ice/3.7/the-slice-language/classes/classes-with-compact-type-ids

--- a/pages/slice/language-guide/class-types.md
+++ b/pages/slice/language-guide/class-types.md
@@ -186,8 +186,8 @@ Normally, this is the class's fully-qualified identifier, which gets encoded as 
 However, to reduce overhead, Slice allows you to assign a numeric type ID to a class instead. For example:
 
 ```slice
-class ClassWithStringTypeId {}     // has a type-id of "ClassWithStringTypeId"
-class ClassWithNumericTypeId(9) {} // has a type-id of `9`
+class ClassWithStringTypeId {}     // has a type ID of "ClassWithStringTypeId"
+class ClassWithNumericTypeId(9) {} // has a type ID of `9`
 ```
 
 Compact type IDs have no effect on the mapping of a class, or the contract for using it.


### PR DESCRIPTION
This PR fixes #332 by adding documentation about compact type IDs for classes.

I here-attach an image of the section for easier viewing.
![image](https://github.com/icerpc/icerpc-docs/assets/25963603/de5b98bf-735c-4f92-91c8-78f47c11a890)

