### PR TITLE
Rewrote the Slice Grammar Reference Page

### DIFF
--- a/pages/slice/language-reference/slice-grammar.md
+++ b/pages/slice/language-reference/slice-grammar.md
@@ -2,14 +2,557 @@
 title: Slice grammar
 ---
 
+This page describes the grammatical rules, usage, and restrictions of the Slice language.
+
+## Slice elements
+
+### Slice files
+
+The `SliceFile` grammar rule is the parser's entry point.
+Once a file's contents have been [preprocessed], the resulting text is matched against this rule, in its entirety.
+
+While the contents of a Slice file may reference things defined in other files, each file is parsed separately.
+There is no notion of 'including' the contents of one file in another, and errors in one file do not affect the parsing of others.
+
+A Slice file consists of an optional [module declaration][module-declaration], followed by any number of Slice definitions.
+Additionally, [file attributes][attribute] and a [mode declaration][mode-declaration] may be specified at the top of a file, before any other definitions.
+Declaring more than one mode in a single file is forbidden.
+
+```ebnf {% showTitle=false %}
+SliceFile
+    : SliceFilePrelude Module? Definition*
+    ;
+
+SliceFilePrelude
+    : EMPTY
+    | SliceFilePrelude FileCompilationMode
+    | SliceFilePrelude FileAttribute
+    ;
+
+Definition
+    : Struct | Class | Exception | Interface | Enum | CustomType | TypeAlias
+    ;
+```
+
+For additional information on Slice files, see the [slice file][slice-file-guide] page.
+
+### Mode declarations
+
+Mode declarations consist of the `mode` keyword, followed by an equals sign, followed by an identifier.
+That identifier must be a valid Slice compilation mode - either `Slice1` or `Slice2`.
+
+```ebnf {% showTitle=false %}
+FileCompilationMode
+    : "mode" "=" Identifier
+    ;
+```
+
+Mode declarations must come before any Slice definitions, including [module declarations][module-declaration].
+While the compilation mode you select will affect which Slice features are available to you,
+it has no effect on the parsing of, or validity of syntax within, your Slice file.
+For example, even though classes are a Slice1-only feature, `class` is still a keyword within a Slice2 file,
+and if you define a class, syntax errors in that class's definition will still be reported normally.
+
+For additional information on modes, see the [compilation mode][compilation-mode-guide] page.
+
+### Module declarations
+
+Module declarations consist of the `module` keyword, followed by an [identifier].
+[local attributes][attribute] can be applied to a module in its prelude, but [doc comments][doc-comment] on modules are forbidden.
+
+```ebnf {% showTitle=false %}
+Module
+    : Prelude "module" RelativeIdentifier
+    ;
+```
+
+If the module's identifier is [unscoped][identifier], this declares a _top-level module_.
+If the module's identifier is [scoped][identifier], this declares a _submodule_.
+
+Submodules are modules that are logically contained within another module (called the _parent_).
+Slice definitions within a submodule can reference types in parent modules without qualification.
+
+```slice
+module A // Declares a top-level module named `A`.
+struct AStruct {}
+```
+
+```slice
+module A::B // Declares a submodule named `B` that is contained within module `A`.
+typealias T = AStruct // Don't need to qualify as `A::AStruct`.
+```
+
+All slice definitions must be contained within modules - Slice definitions cannot exist at 'global' scope.
+If a Slice file contains no Slice definitions, it is legal to omit the module declaration.
+Otherwise, if a Slice file contains any Slice definitions, a module declaration is required,
+and any Slice definitions in the remainder of the file will be contained within the declared module.
+
+Module declarations must come before any Slice definitions and must come after any [file attributes][attribute] or [mode declarations][mode-declaration].
+There can be at most one module declaration per Slice file.
+
+```ebnf {% showTitle=false %}
+SliceFile
+    : SliceFilePrelude Module? Definition*
+    ;
+```
+
+It is legal for multiple Slice files to declare the same module.
+Slice definitions defined in those files will be in the same module, even if they're in different Slice files.
+
+For additional information on modules, see the [module][module-guide] page.
+
+### Primitive types
+
+Slice supports 17 primitive types (although `AnyClass` is only valid in [`Slice1`][compilation-mode-guide] mode).
+Primitive types are always available: they're defined in any scope of any Slice file.
+They can be referenced with their keywords:
+
+```ebnf {% showTitle=false %}
+Primitive
+    : "bool"      | "int8"  | "uint8"  | "int16"    | "uint16"    | "int32"   | "uint32"  | "varint32"
+    | "varuint32" | "int64" | "uint64" | "varint62" | "varuint62" | "float32" | "float64" | "string"
+    | "AnyClass"
+    ;
+```
+
+For additional information on primitive types, see the [primitive type][primitive-type-guide] page.
+
+### Collection types
+
+Slice supports 2 built-in collection types: sequences and dictionaries.
+Both types can be referenced with their respective keywords: `Sequence` and `Dictionary`,
+
+```ebnf {% showTitle=false %}
+Sequence
+    : "sequence" "<" TypeRef ">"
+    ;
+
+Dictionary
+    : "dictionary" "<" TypeRef "," TypeRef ">"
+    ;
+```
+
+Since they are are generic over the types of elements they contain, you must also specify their type arguments:
+
+```slice
+Sequence<bool>
+Dictionary<uint8, string>
+```
+
+Since dictionary keys must be comparable, there are restrictions on which types can be used for them.
+For additional information on sequences and dictionaries, see the [sequence][sequence-guide] and [dictionary][dictionary-guide] pages.
+
+### Struct types
+
+Struct definitions consist of the `struct` keyword, followed by an [identifier], and then the struct's body.
+Struct bodies consist of a list of [fields][field] wrapped in a pair of braces. These fields may be optionally separated by commas.
+Additionally, [local attributes][attribute] and a [doc-comment] may be applied to the struct in its prelude.
+
+```ebnf {% showTitle=false %}
+Struct
+    : Prelude "compact"? "struct" Identifier "{" UndelimitedList<Field> "}"
+    ;
+```
+
+Structs also support the `compact` modifier keyword.
+A [compact struct][compact-struct-guide] cannot contain [tagged fields][tag].
+
+For additional information on structs, see the [struct][struct-guide] page.
+
+### Class types
+
+Classes can only be defined or referenced in [`Slice1`][compilation-mode-guide] mode.
+Classes can never be tagged when used as the type of a [field] or [parameter].
+
+Class definitions consist of the `class` keyword, followed by an [identifier], optionally followed by a [compact ID][compact-id-guide], optionally followed by a base class, and then the class's body.
+Compact IDs consist of a (possibly signed) integer wrapped in a pair of parenthesis.
+Base classes are specified by a single colon, followed by a class's (possibly scoped) identifier.
+Class bodies consist of a list of [fields][field] wrapped in a pair of braces. These fields may be optionally separated by commas.
+Additionally, [local attributes][attribute] and a [doc-comment] may be applied to the class in its prelude.
+
+```ebnf {% showTitle=false %}
+Class
+    : Prelude "class" Identifier CompactId? (":" TypeRef)? "{" UndelimitedList<Field> "}"
+    ;
+
+CompactId
+    : "(" SignedInteger ")"
+    ;
+```
+
+For additional information on classes, see the [class][class-guide] page.
+
+### Exceptions
+
+Exceptions can only be defined or referenced in [`Slice1`][compilation-mode-guide] mode.
+Exceptions cannot be used as types. They can only validly appear in the exception specification of [operations][operation].
+
+Exception definitions consist of the `exception` keyword, followed by an [identifier], optionally followed by a base exception, and then the exception's body.
+Base exceptions are specified by a single colon, followed by an exception's (possibly scoped) identifier.
+Exception bodies consist of a list of [fields][field] wrapped in a pair of braces. These fields may be optionally separated by commas.
+Additionally, [local attributes][attribute] and a [doc-comment] may be applied to the exception in its prelude.
+
+```ebnf {% showTitle=false %}
+Exception
+    : Prelude "exception" Identifier (":" TypeRef)? "{" UndelimitedList<Field> "}"
+    ;
+```
+
+For additional information on exceptions, see the [exception][exception-guide] page.
+
+### Fields
+
+Fields can only be declared within [structs][struct], [classes][class], and [exceptions][exception].
+Field declarations consist of an [identifier], followed by a colon, and then a [type].
+Optionally, a [tag] may be applied to the field, directly before its identifier, making this a [tagged field][tag].
+Additionally, [local attributes][attribute] and a [doc-comment][doc-comment] may be applied to the field in its prelude.
+
+```ebnf {% showTitle=false %}
+Field
+    : Prelude Tag? Identifier ":" TypeRef
+    ;
+```
+
+For additional information on fields, see the [field][field-guide] page.
+
+### Interfaces
+
+Interface definitions consist of the `interface` keyword, followed by an [identifier], optionally followed by a list of base interfaces, and then the interface's body.
+Base interfaces are specified by a single colon, followed by the (possibly scoped) identifiers of one or more interfaces, separated by commas.
+Interface bodies consist of a set of [operations][operation] wrapped in a pair of braces.
+Additionally, [local attributes][attribute] and a [doc-comment] may be applied to the class in its prelude.
+
+```ebnf {% showTitle=false %}
+Interface
+    : Prelude "interface" Identifier (":" NonEmptyCommaList<TypeRef>)? "{" Operation* "}"
+    ;
+```
+
+If you are using an RPC framework, every interface definition also defines a _proxy type_.
+This proxy type shares the same name and scope as its corresponding interface and can be used as a type.
+
+```slice
+interface Foo { // Defines an interface named `Foo`.
+    op() -> Foo // Returns a proxy named `Foo`.
+}
+```
+
+It is illegal to use an interface as a type without an RPC framework.
+
+For additional information on interfaces and proxies, see the [interface][interface-guide] and [proxy][proxy-guide] pages.
+
+### Operations
+
+An operation consists of an [identifier], followed be a list of [parameters][parameter], optionally followed by a return type, optionally followed by an [exception specification][exception-specification-guide].
+Operations support the `idempotent` modifier keyword. For information about its effects, see the [idempotent][idempotent-guide] section.
+Additionally, [local attributes][attribute] and a [doc-comment] may be applied to the operation in its prelude.
+
+```ebnf {% showTitle=false %}
+Operation
+    : Prelude "idempotent"? Identifier "(" UndelimitedList<Parameter> ")" ReturnType? ExceptionSpecification?
+    ;
+```
+
+There are two syntaxes for specifying a return type, depending on the number of elements you're returning.
+A single return type can be specified by an arrow, followed by an optional [tag], followed by an optional [`stream`][stream-guide] keyword, and then a [type].
+The syntax of a single return type is identical to a [parameter], but without an identifier or colon separator.
+Multiple return parameters can be specified as a tuple. This consists of an arrow, followed by a list of [parameters][parameter] wrapped in parenthesis.
+It is illegal for a return tuple to contain less than 2 elements. 
+
+```ebnf {% showTitle=false %}
+ReturnType
+    : "->" Tag? "stream"? TypeRef
+    | "->" "(" UndelimitedList<Parameter> ")"
+    ;
+```
+
+There are two syntaxes for [exception specifications][exception-specification-guide], depending on the number of [exceptions][exception] being specified.
+A single exception can be specified with the `throws` keyword, followed by the (possibly scoped) identifier of an exception.
+Multiple exceptions can be specified as a tuple. This consists of the `throws` keyword, followed by the (possibly scoped) identifiers of one or more exceptions, separated by commas.
+
+```ebnf {% showTitle=false %}
+ExceptionSpecification
+    : "throws" TypeRef
+    | "throws" "(" NonEmptyCommaList<TypeRef> ")"
+    ;
+```
+
+Parameter lists may be optionally separated by commas. This applies to both operation parameters and return parameters.
+
+For additional information on operations, see the [operation][operation-guide] pages.
+
+### Parameters
+
+The syntax for parameters is identical to the syntax for [fields][field], but with added support for the `stream` modifier keyword.
+
+Parameters consist of an [identifier], followed by a colon, and then a [type].
+Optionally, a [tag] may be applied to the parameter, directly before its identifier, making this a [tagged parameter][tag].
+Additionally, [local attributes][attribute] and a [doc-comment] may be applied to the field in its prelude.
+
+```ebnf {% showTitle=false %}
+Parameter
+    : Prelude Tag? Identifier ":" "stream"? TypeRef
+    ;
+```
+
+Parameters also support the [`stream`][stream-guide] modifier keyword, which may be applied to the parameter's type.
+
+For additional information on parameters, see the [parameter][parameter-guide] pages.
+
+### Enum types
+
+Enum definitions consist of the `enum` keyword, followed by an [identifier], optionally followed by an [underlying type][type], and then the enum's body.
+Underlying types are specified by a single colon, followed by a type.
+Underlying types must be integral and non-optional. Enums have a default underlying type of [varint32][primitive] if none is specified.
+Enum bodies consist of a list of [enumerators][enumerator] wrapped in a pair of braces. These enumerators may be optionally separated by commas.
+Additionally, [local attributes][attribute] and a [doc-comment] may be applied to the enum in its prelude.
+
+```ebnf {% showTitle=false %}
+Enum
+    : Prelude "unchecked"? "enum" Identifier (":" TypeRef)? "{" UndelimitedList<Enumerator> "}"
+    ;
+```
+
+Enums also support the `unchecked` modifier keyword.
+An [unchecked-enum][unchecked-enum-guide] can be empty. An enum without this modifier must have at least one enumerator.
+
+For additional information on enums, see the [enum][enum-guide] page.
+
+### Enumerators
+
+Enumerators can only be defined within [enums][enum].
+Enumerator definitions consist of an [identifier], optionally followed by an enumerator value.
+Enumerator values consist of an equals sign, followed by a (possibly signed) [integer].
+Additionally, [local attributes][attribute] and a [doc-comment] may be applied to the enumerator in its prelude.
+
+```ebnf {% showTitle=false %}
+Enumerator
+    : Prelude Identifier ("=" SignedInteger)?
+    ;
+```
+
+The enum that an enumerator is defined within determines the allowed values;
+An enumerator's value must be within the bounds of the enum's underling type.
+
+For additional information on enumerators, see the [enumerator][enum-guide] page.
+
+### Custom types
+
+Custom type definitions consist of the `custom` keyword, followed by an [identifier].
+Additionally, [local attributes][attribute] and a [doc-comment] may be applied to the custom type in its prelude.
+
+```ebnf {% showTitle=false %}
+CustomType
+    : Prelude "custom" Identifier
+    ;
+```
+
+For a custom type to be mappable, it must have a `[x::type]` attribute applied to it, where `x` is the mapping language's prefix.
+
+For additional information on custom types, see the [custom type][custom-type-guide] page.
+
+### Type aliases
+
+Type alias definitions consist of the `typealias` keyword, followed by an [identifier], followed by an equals sign, and then a [type].
+Additionally, [local attributes][attribute] and a [doc-comment] may be applied to the type alias in its prelude.
+
+```ebnf {% showTitle=false %}
+TypeAlias
+    : Prelude "typealias" Identifier "=" TypeRef
+    ;
+```
+
+Type aliases can be used anywhere a type can be used, and behave identically to their underlying type.
+It is legal for type aliases to alias other type aliases.
+
+For additional information on type aliases, see the [type alias][type-alias-guide] page.
+
+### Type references
+
+Type references consist of any number of [type attributes][attribute], followed a type, optionally followed by a question mark.
+
+Built-in types like [primitives][primitive], [sequences][sequence], and [dictionaries][dictionary] can be referenced by their keywords.
+User defined types can be referenced by their (possibly scoped) [identifiers][identifier].
+
+```ebnf {% showTitle=false %}
+TypeRef
+    : LocalAttribute* TypeRefDefinition "?"?
+    ;
+
+TypeRefDefinition
+    : Primitive | Sequence | Dictionary | RelativeIdentifier | GlobalIdentifier
+    ;
+```
+
+### Identifiers
+
+Slice supports three forms of identifiers:
+- An unscoped identifier. These consist of a letter, followed by any number of letters, digits, or underscores.
+- A relatively scoped identifier. These consist of one or more unscoped identifiers, separated by `::` tokens.
+- A globally scoped identifier. These consist of a `::` token, followed by a relatively scoped identifier.
+
+```ebnf {% showTitle=false %}
+Identifier
+    : identifier
+    ;
+
+RelativeIdentifier
+    : identifier ("::" identifier)*
+    ;
+
+GlobalIdentifier
+    : ("::" identifier)+
+    ;
+```
+
+Examples of valid identifiers:
+
+```slice
+// Examples of unscoped identifiers
+foo9
+_bar_
+BAZ
+
+// Examples of relatively scoped identifiers
+foo9
+foo9::_bar_::BAZ
+
+// Examples of globally scoped identifiers
+::foo9
+::foo9::_bar_::BAZ
+```
+
+All Slice [keywords] satisfy the definition of an unscoped identifier.
+Hence the lexer always gives priority to producing keyword tokens, even when it could produce an identifier token.
+To use a keyword as an identifier, you can escape the keyword by prefixing it with a backslash.
+For scoped identifiers, each individual identifier must be escaped this way.
+It is legal to escape an identifier that is not a keyword, though doing so has no effect.
+
+```slice
+struct   // The struct keyword
+\struct  // An unscoped identifier
+\foo     // An unscoped identifier
+
+::\struct::\module // A globally scoped identifier
+```
+
+### Integer literals
+
+Slice supports three forms of integer literals:
+- A decimal literal for base-10 numbers. These consist of one or more digits between `0` and `9`.
+- A hexadecimal literal for base-16 numbers. These start with the prefix `0x`, followed by one or more digits between `0` and `9` or letters between `a` and `f`. Hexadecimal literals are not case-sensitive.
+- A binary literal for base-2 numbers. These start with the prefix `0b`, followed by one or more digits that are either `0` or `1`.
+
+Additionally, underscores can appear between any two characters of an integer literal.
+These underscores carry no semantic meaning and are discarded by the parser.
+
+Examples of valid integer literals:
+
+```slice
+123
+0xFF
+0b1010
+
+335_445_996
+0x_ab_cd_ef  // Same as 0xabcded
+0b0_______1  // Same as 0b01
+
+0x_0b1101  // hexadecimal literal of value 725249
+
+// All have a value of 0
+0
+0_00_0
+0b000
+0x0
+```
+
+{% callout type="note" %}
+Note that `-` signs are counted as separate tokens, and not as part of an integer literal.
+{% /callout %}
+
+The Slice grammar has 2 separate rules for unsigned and (possibly) signed integers.
+Slice does not support using a `+` sign to indicate an integer is positive, since all integers are positive by default.
+
+```ebnf {% showTitle=false %}
+Integer
+    : integer_literal
+    ;
+
+SignedInteger
+    : Integer
+    | "-" Integer
+    ;
+```
+
+### String literals
+
+String literals consist of any number of UTF8 characters, wrapped in a pair of double quotes.
+Any characters within a string literal are treated as opaque text by the parser.
+
+Slice supports escaping special characters within string literals, this allows you to include unprintable characters or literal double quote characters in your string. Characters can be escaped by prefixing them with a backslash.
+To write a literal backslash, you must escape it with another backslash: `\\`.
+
+When parsing, Slice will resolve any escaped characters, removing the `\` escape character where present.
+Apart from this, Slice performs no additional processing of string literals.
+
+Examples of valid string literals:
+
+```slice
+""
+"hello world"
+"the variable \"foo\" doesn't exist"
+"a backslash: '\\'"
+```
+
+### Attributes
+
+Slice supports two forms of attributes:
+- Local attributes: these consist of an attribute wrapped in a pair of single brackets.
+- File attributes: these consist of an attribute wrapped in a pair of double brackets.
+
+Local attributes can be applied to most Slice definitions by placing them directly before the definition.
+File attributes apply to an entire [slice file][slice-file] and must appear before any Slice definitions or module declarations.
+
+```ebnf {% showTitle=false %}
+FileAttribute
+    : "[[" Attribute "]]"
+    ;
+
+LocalAttribute
+    : "[" Attribute "]"
+    ;
+```
+
+An attribute consists of a directive, optionally followed by attribute arguments.
+A directive is syntactically equivalent to a [scoped identifier][identifier], but instead of Slice scopes, its scopes determine when the attribute is meaningful.
+For example, a directive with no scope like `deprecated` will always apply, but a directive like `cs::type` will only apply when running `slicec-cs`.
+Attribute arguments consist of any number of arguments wrapped in a pair of parenthesis, separated by commas.
+Arguments may be either a [string literal][string] or an [unscoped identifier][identifier].
+
+```ebnf {% showTitle=false %}
+Attribute
+    : RelativeIdentifier ("(" CommaList<AttributeArgument> ")")?
+    ;
+
+AttributeArgument
+    : string_literal | identifier
+    ;
+```
+
+How many arguments are accepted/required is up to the directive.
+But supplying too many or too few arguments is never a syntax error.
+
+For additional information on attributes, see the [attribute] page.
+
 ## Lexical grammar
 
-This lexical grammar is not strictly context-free due to the following behavior:
+This section describes how Unicode characters combine to form the tokens used in the syntactic grammar.
 
-When a compliant lexer has seen a '[' character and hasn't encountered a ']' since the '[',
-it must prioritize producing `identifier` symbols over other symbols.
-This allows attribute directives and arguments to accept strings that would normally produce keyword tokens.
-While context dependent, this behavior is still unambiguous, since keywords cannot validly appear in attributes.
+{% callout type="note" %}
+While it is modeled as a context-free grammar, there is one case where the lexer's behavior is context dependent:
+when lexing the inside of an attribute (any characters between a pair of `[` and `]` or `[[` and `]]` tokens)
+the lexer will not produce keyword tokens. Keywords will be treated as identifiers, as if they were prefixed with a backslash.
+{% /callout %}
 
 ```ebnf {% showTitle=false %}
 identifier: "\\"? LETTER ALPHANUMERIC*;
@@ -84,18 +627,9 @@ arrow:         "->";
 minus:         "-";
 ```
 
-### Case sensitivity
-
-Slice keywords and identifiers are case-sensitive. For example, `TimeOfDay` and `TIMEOFDAY` are
-considered different identifiers.
-
-### Using a keyword as an identifier
-
-It is possible to use a Slice keyword as an identifier by prefixing the keyword with a backslash (`\`).
-
-It's best to avoid using Slice keywords as identifiers.
-
 ## Syntactic grammar
+
+This section describes how lexical tokens combine to form elements of the Slice language.
 
 ```ebnf {% showTitle=false %}
 SliceFile
@@ -286,3 +820,46 @@ UndelimitedList<T>
     : (T comma?)*
     ;
 ```
+
+[slice-file]: #slice-files
+[module-declaration]: #module-declarations
+[mode-declaration]: #mode-declarations
+[primitive]: #primitive-types
+[sequence]: #collection-types
+[dictionary]: #collection-types
+[struct]: #struct-types
+[class]: #class-types
+[exception]: #exception
+[field]: #fields
+[operation]: #operations
+[parameter]: #parameters
+[enum]: #enum-types
+[enumerator]: #enumerators
+[identifier]: #identifiers
+[attribute]: #attributes
+[type]: #type-references
+[integer]: #integer-literals
+[string]: #string-literals
+
+[slice-file-guide]: /slice/basics/slice-files
+[compilation-mode-guide]: /slice/language-guide/compilation-mode
+[module-guide]: slice/language-guide/module
+[primitive-type-guide]: /slice/language-guide/primitive-types
+[sequence-guide]: /slice/language-guide/sequence-types
+[dictionary-guide]: /slice/language-guide/dictionary-types
+[struct-guide]: /slice/language-guide/struct-types
+[compact-struct-guide]: /slice/language-guide/struct-types#compact-struct
+[class-guide]: /slice1/language-guide/class-types
+[compact-id-guide]: /slice/language-guide/class-types#compact-type-ids
+[exception-guide]: /slice/language-guide/exception
+[field-guide]: /slice/language-guide/fields
+[interface-guide]: /slice/language-guide/interface
+[proxy-guide]: /slice/language-guide/proxy-types
+[operation-guide]: /slice/language-guide/operation
+[exception-specification-guide]: /slice/language-guide/operation#exception-specification
+[idempotent-guide]: /slice/language-guide/operation#idempotent-operation
+[parameter-guide]: /slice/language-guide/parameters
+[enum-guide]: /slice/language-guide/enum-types
+[unchecked-enum-guide]: /slice/language-guide/enum-types#unchecked-enumeration
+[custom-type-guide]: /slice/language-guide/custom-types
+[type-alias-guide]: /slice/language-guide/type-alias


### PR DESCRIPTION
This PR rewrites the Slice grammar page of the language reference.
Each grammar element gets it's own section with a brief explanation, and a snippet from it's relevant grammar rule.

The page still features both the lexical and syntactical grammars at the bottom, as appendices.
These still seem common to feature, in addition to the more detailed breakdown. See:
https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/grammar#a2-lexical-grammar

It doesn't make the page visible again, because the preprocessor and comment reference pages still need rewriting.
Once we get a structure and tone that everyone is okay with, I'll do those pages as well, then re-add them to the sidebar.

----

I'm aware some lines overflow the 120 column limit. I'll format the file once everyone is okay with the content.
Letting them overflow for now makes it easier to review and offer code suggestions.