### PR TITLE
Updated example URLs to use 0.1.x branch

### DIFF
--- a/components/tags/examples.tsx
+++ b/components/tags/examples.tsx
@@ -10,17 +10,17 @@ export const Examples = () => {
       <ExampleCard
         title="GreeterLog"
         description="A typical IceRPC application."
-        href="https://github.com/icerpc/icerpc-csharp/tree/main/examples/GreeterLog"
+        href="https://github.com/icerpc/icerpc-csharp/tree/0.1.x/examples/GreeterLog"
       />
       <ExampleCard
         title="GenericHost"
         description="IceRPC with the Microsoft DI container."
-        href="https://github.com/icerpc/icerpc-csharp/tree/main/examples/GenericHost"
+        href="https://github.com/icerpc/icerpc-csharp/tree/0.1.x/examples/GenericHost"
       />
       <ExampleCard
         title="Stream"
         description="Stream your data with IceRPC and Slice."
-        href="https://github.com/icerpc/icerpc-csharp/tree/main/examples/Stream"
+        href="https://github.com/icerpc/icerpc-csharp/tree/0.1.x/examples/Stream"
       />
     </div>
   );

--- a/content/icerpc/index.md
+++ b/content/icerpc/index.md
@@ -146,17 +146,17 @@ integration will soon bring the same level of convenience to Protobuf.
 {% mini-card
    title="Core example"
    description="Using IceRPC without an IDL."
-   href="https://github.com/icerpc/icerpc-csharp/tree/main/examples/GreeterCore" /%}
+   href="https://github.com/icerpc/icerpc-csharp/tree/0.1.x/examples/GreeterCore" /%}
 
 {% mini-card
    title="JSON example"
    description="Using IceRPC with JSON."
-   href="https://github.com/icerpc/icerpc-csharp/tree/main/examples/GreeterJson" /%}
+   href="https://github.com/icerpc/icerpc-csharp/tree/0.1.x/examples/GreeterJson" /%}
 
 {% mini-card
    title="Protobuf example"
    description="Using IceRPC with Protobuf."
-   href="https://github.com/icerpc/icerpc-csharp/tree/main/examples/GreeterProtobuf" /%}
+   href="https://github.com/icerpc/icerpc-csharp/tree/0.1.x/examples/GreeterProtobuf" /%}
 
 {% /grid %}
 

--- a/content/slice/language-guide/parameters.md
+++ b/content/slice/language-guide/parameters.md
@@ -81,7 +81,7 @@ case. The type of the C# field is the mapped C# type for `Type`.
 Tagged parameters are mapped just like regular parameters. The tag and tag number don't appear in the mapped C# API.
 
 {% slice2 %}
-### Stream parameters in C #
+### Stream parameters in C#
 
 A stream parameter of type `uint8` is mapped to a [PipeReader]. For example:
 

--- a/content/slice/language-guide/parameters.md
+++ b/content/slice/language-guide/parameters.md
@@ -10,22 +10,27 @@ Parameters have the same syntax as [fields](fields), with one exception: when an
 this parameter cannot have a name. The syntax for this nameless return parameter is simply `Type` or `tag(N) Type?`.
 
 For example:
+
 ```slice
 greet(name: string) -> string // the return parameter has a type (string) but no name.
 anotherGreet(name: string) -> tag(1) string? // the return parameter is tagged
 ```
+
 {% /slice1 %}
 {% slice2 %}
 Parameters have the same syntax as [fields](fields), with two extensions:
 
 1. When an operation returns a single parameter, this parameter cannot have a name. The syntax for this nameless return
 parameter is simply `Type` or `tag(N) Type?`. For example:
+
     ```slice
     greet(name: string) -> string // the return parameter has a type (string) but no name.
     anotherGreet(name: string) -> tag(1) string? // the return parameter is tagged
     ```
+
 2. The last parameter of an operation or return type may be a stream parameter, with the `stream` keyword before the
 type. For example:
+
     ```slice
     downloadFile(name: string) -> stream uint8
 
@@ -76,11 +81,12 @@ case. The type of the C# field is the mapped C# type for `Type`.
 Tagged parameters are mapped just like regular parameters. The tag and tag number don't appear in the mapped C# API.
 
 {% slice2 %}
-### Stream parameters in C#
+### Stream parameters in C #
 
 A stream parameter of type `uint8` is mapped to a [PipeReader]. For example:
 
 {% side-by-side alignment="top" %}
+
 ```slice
 interface ImageStore {
     uploadImage(name: string, bytes: stream uint8)
@@ -97,6 +103,7 @@ public partial interface IImageStore
         CancellationToken cancellationToken = default);
 }
 ```
+
 {% /side-by-side %}
 
 When you give such a stream to the generated code, the IceRPC + Slice integration will complete this stream when it's
@@ -110,6 +117,7 @@ For all other stream element types, a stream parameter is mapped to an [`IAsyncE
 the async enumerable element type is the mapped C# type for the Slice stream element type. For example:
 
 {% side-by-side alignment="top" %}
+
 ```slice
 interface TemperatureProbe {
     read() -> stream float32
@@ -124,6 +132,7 @@ public partial interface ITemperatureProbe
         CancellationToken cancellationToken = default);
 }
 ```
+
 {% /side-by-side %}
 
 When you give such a stream to the generated code, the IceRPC + Slice integration will either iterate over all the
@@ -141,6 +150,6 @@ blocked or slow read operation on the underlying byte stream. {% /slice2 %}
 [PipeReader]: https://learn.microsoft.com/en-us/dotnet/api/system.io.pipelines.pipereader
 [Complete]: https://learn.microsoft.com/en-us/dotnet/api/system.io.pipelines.pipereader.complete
 [CompleteAsync]: https://learn.microsoft.com/en-us/dotnet/api/system.io.pipelines.pipereader.completeasync
-[Stream example]: https://github.com/icerpc/icerpc-csharp/tree/main/examples/Stream
+[Stream example]: https://github.com/icerpc/icerpc-csharp/tree/0.1.x/examples/Stream
 [WithCancellation]: https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.taskasyncenumerableextensions.withcancellation
 [`IAsyncEnumerable<T>`]: https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.iasyncenumerable-1


### PR DESCRIPTION
Closes #382 

Missed the original intent of #382 with #383. I have updated that PR accordingly.
This PR updates the live version of the website to point to the `0.1.x` branch instead of `main`.