### PR TITLE
Restructure top navigation bar

### DIFF
--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -103,7 +103,7 @@ export default async function Page({ params }: PageProps) {
   }
 
   return (
-    <div className="mt-[6.5rem] flex grow flex-row justify-center lg:mt-[3.75rem]">
+    <div className="mt-[6.4rem] flex grow flex-row justify-center lg:mt-[7.5rem]">
       <div className="flex max-w-[100rem] grow flex-row justify-center">
         <SideNav path={path} />
         <div className="grow">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,7 +10,7 @@ import { License } from '@/components/tags/license';
 
 export default async function Home() {
   return (
-    <div className="mt-[3.75rem] flex grow flex-row justify-center lg:mt-[3.75rem]">
+    <div className="mt-[6.4rem] flex grow flex-row justify-center lg:mt-[7.5rem]">
       <div className="relative flex max-w-[120rem] grow flex-col items-center justify-center">
         <div id="skip-nav" />
         <Hero />

--- a/components/shell/aside.tsx
+++ b/components/shell/aside.tsx
@@ -37,7 +37,7 @@ export const Aside = ({
   return (
     <aside
       className={clsx(
-        'sticky top-[3.75rem] mr-10 hidden h-[calc(100vh-4rem)] w-[275px] shrink-0 dark:bg-dark xl:flex',
+        'sticky top-[6.4rem] mr-10 hidden h-[calc(100vh-4rem)] w-[275px] shrink-0 dark:bg-dark xl:flex',
         items.length > 1 ? '' : ''
       )}
     >

--- a/components/shell/side-navigation/side-nav-selector.tsx
+++ b/components/shell/side-navigation/side-nav-selector.tsx
@@ -19,32 +19,35 @@ export const SideNavSelector = ({
   return (
     <>
       {isSlicePage && (
-        <SliceSelector
-          className="w-full"
-          onChangeCallback={(mode) => {
-            const [corePath, fragment] = path.split('#');
+        <>
+          <SliceSelector
+            className="mt-3 w-full"
+            onChangeCallback={(mode) => {
+              const [corePath, fragment] = path.split('#');
 
-            let newPath;
-            if (corePath === '/slice1') {
-              newPath = mode === Mode.Slice1 ? '/slice1' : '/slice2';
-            } else if (corePath === '/slice2') {
-              newPath = mode === Mode.Slice1 ? '/slice1' : '/slice2';
-            } else {
-              newPath = corePath.replace(
-                /\/slice[1-2]\//,
-                `/slice${mode === Mode.Slice1 ? 1 : 2}/`
-              );
-            }
+              let newPath;
+              if (corePath === '/slice1') {
+                newPath = mode === Mode.Slice1 ? '/slice1' : '/slice2';
+              } else if (corePath === '/slice2') {
+                newPath = mode === Mode.Slice1 ? '/slice1' : '/slice2';
+              } else {
+                newPath = corePath.replace(
+                  /\/slice[1-2]\//,
+                  `/slice${mode === Mode.Slice1 ? 1 : 2}/`
+                );
+              }
 
-            // Append the fragment back, if it exists
-            if (fragment) {
-              newPath = `${newPath}#${fragment}`;
-            }
+              // Append the fragment back, if it exists
+              if (fragment) {
+                newPath = `${newPath}#${fragment}`;
+              }
 
-            push(newPath);
-            setMode(mode);
-          }}
-        />
+              push(newPath);
+              setMode(mode);
+            }}
+          />
+          <div className="w-full border-t-[1px] border-lightBorder pb-4 dark:border-darkBorder" />
+        </>
       )}
     </>
   );

--- a/components/shell/side-navigation/side-nav.tsx
+++ b/components/shell/side-navigation/side-nav.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
 import { sideBarData, baseUrls } from 'data';
-import { SearchButton } from '@/components/shell/search-button';
 import { SideNavList } from './side-nav-list';
 import { SideNavSelector } from './side-nav-selector';
 
@@ -21,16 +20,14 @@ export const SideNav = ({ path }: { path: string }) => {
   const isSlicePage = ['/slice1', '/slice2'].includes(baseUrl);
 
   return (
-    <div className="sticky top-[59px] hidden h-[calc(100vh-59px)] flex-none flex-col items-end border-r border-lightBorder dark:border-darkBorder/60 dark:bg-dark lg:flex">
+    <div className="sticky top-[6.4rem] hidden h-[calc(100vh-59px)] flex-none flex-col items-end border-r border-lightBorder dark:border-darkBorder/60 dark:bg-dark lg:flex">
       <div className="flex h-full w-full min-w-[300px] max-w-[300px] flex-col justify-start overflow-y-auto pl-10">
         <div className="sticky top-0 space-y-5 bg-[#fafafa] pr-6 dark:bg-dark">
-          <SearchButton className="mb-0 mt-6 flex items-start" />
           <SideNavSelector isSlicePage={isSlicePage} path={path} />
-          <div className="w-full border-t-[1px] border-lightBorder dark:border-darkBorder" />
           <div className="pointer-events-none absolute inset-x-0 bottom-[-2.25rem] h-9 w-full bg-gradient-to-t from-transparent to-[#fafafa] dark:to-dark" />
         </div>
         <nav>
-          <ul className="top-0 mr-2 mt-5">{cells}</ul>
+          <ul className="top-0 mb-2 mr-2 mt-4">{cells}</ul>
           <div className="pointer-events-none sticky inset-x-0 bottom-0 h-10 w-full bg-gradient-to-t from-[#fafafa] to-transparent dark:from-dark " />
         </nav>
       </div>

--- a/components/shell/top-navigation/top-nav.tsx
+++ b/components/shell/top-navigation/top-nav.tsx
@@ -12,6 +12,7 @@ import { ThemeToggle } from '@/components/theme-toggle';
 import logoIcon from 'public/Icerpc-logo.svg';
 import { TopNavigationItems } from './top-nav-items';
 import { Button } from '@/components/ui/button';
+import { SearchButton } from '@/components/shell/search-button';
 
 export const TopNav = () => (
   <div
@@ -20,34 +21,42 @@ export const TopNav = () => (
       'dark:border-darkBorder/60 dark:bg-dark'
     )}
   >
-    <div id="main-nav" className="flex w-full justify-center">
-      <div className="flex h-[3.75rem] w-full max-w-[100rem] items-center justify-between text-sm">
-        <Logo />
-        <div className="hidden items-center lg:flex">
-          <nav>
-            <ul className="flex">
+    <div
+      id="main-nav"
+      className="flex w-full flex-col items-center justify-center"
+    >
+      <div className="w-full max-w-[100rem] ">
+        <div className="flex h-[3.75rem] w-full grow  items-center justify-between text-sm">
+          <Logo />
+          <div className="hidden items-center lg:flex">
+            <SearchButton className="w-full min-w-[300px]" />
+            <div className="mx-6 flex h-[30px] items-center border-l border-lightBorder pl-4 dark:border-darkBorder">
+              <ThemeToggle />
+              <Button
+                variant="outline"
+                size="icon"
+                className="border-none hover:bg-zinc-100 focus-visible:border-0 focus-visible:!outline-none focus-visible:ring-transparent dark:!outline-none dark:hover:bg-darkAccent dark:focus-visible:!border-0"
+              >
+                <a
+                  className="flex h-full items-center justify-center p-4 dark:text-[rgba(255,255,255,0.8)] "
+                  href="https://github.com/icerpc"
+                  rel="noopener noreferrer"
+                  aria-label="Github"
+                >
+                  <FontAwesomeIcon icon={faGithub} className="h-5 w-5" />
+                </a>
+              </Button>
+            </div>
+          </div>
+          <MobileMenu />
+        </div>
+        <div className="flex w-full grow items-start   justify-between text-sm lg:h-[2.65rem]">
+          <nav className="my-1 hidden items-center lg:flex">
+            <ul className="flex space-x-4 lg:ml-[1.8rem]">
               <TopNavigationItems />
             </ul>
           </nav>
-          <div className="mx-6 flex h-[30px] items-center border-l border-lightBorder pl-4 dark:border-darkBorder">
-            <ThemeToggle />
-            <Button
-              variant="outline"
-              size="icon"
-              className="border-none hover:bg-zinc-100 focus-visible:border-0 focus-visible:!outline-none focus-visible:ring-transparent dark:!outline-none dark:hover:bg-darkAccent dark:focus-visible:!border-0"
-            >
-              <a
-                className="flex h-full items-center justify-center p-4 dark:text-[rgba(255,255,255,0.8)] "
-                href="https://github.com/icerpc"
-                rel="noopener noreferrer"
-                aria-label="Github"
-              >
-                <FontAwesomeIcon icon={faGithub} className="h-5 w-5" />
-              </a>
-            </Button>
-          </div>
         </div>
-        <MobileMenu />
       </div>
     </div>
     <MobileSideNav />

--- a/components/shell/top-navigation/top-navigation-item.tsx
+++ b/components/shell/top-navigation/top-navigation-item.tsx
@@ -15,9 +15,9 @@ const TopNavigationItem = ({ name, href }: TopNavigationItemProps) => {
   const path = usePathname();
   const prefetch = href.startsWith('http') ? false : undefined;
   const baseClassName =
-    'mx-3 overflow-hidden whitespace-nowrap dark:text-[rgba(255,255,255,0.6)] hover:text-zinc-900 dark:hover:text-white';
+    'mx-3 overflow-hidden whitespace-nowrap font-medium dark:text-[rgba(255,255,255,0.6)] hover:text-zinc-900 dark:hover:text-white';
   const activeClassName =
-    'mx-3 text-primary font-semibold no-underline decoration-2 underline-offset-[1.5rem] opacity-100 dark:text-white hover:!text-primary dark:hover:!text-white';
+    'mx-3 text-primary font-semibold underline decoration-2 underline-offset-[1.22rem] opacity-100 dark:text-white hover:!text-primary dark:hover:!text-white';
   const isActive = isActivePath(path, href);
   const linkClassName = clsx(baseClassName, isActive && activeClassName);
 


### PR DESCRIPTION
Closes #391 

Our issue with the search still working even on the home page was that we currently show the search button on mobile landing page but not on desktop. This type of inconsitency is bad + makes it confusing to know when to allow the keyboard shortcuts for triggering search.

This PR restructures the navigation so the search bar is always at the top. As such, it moved it out of the side navigation. Additionally, this PR moves the top links to a second row so they have more room to breath since the search bar is now in the top bar. I think this will be needed in the future anyway as we expand the documentation.

---

**Before:**

<img width="1554" alt="Screenshot 2023-11-22 at 12 12 05 PM" src="https://github.com/icerpc/icerpc-docs/assets/14209515/0ca9b0d2-a959-4c15-820c-397e3dc0c965">


**After:**

<img width="1554" alt="Screenshot 2023-11-22 at 12 11 20 PM" src="https://github.com/icerpc/icerpc-docs/assets/14209515/db251bce-db54-434b-abb8-8166b519939b">

