### PR TITLE
Don't use code block in API links

### DIFF
--- a/content/slice/language-guide/exception.md
+++ b/content/slice/language-guide/exception.md
@@ -144,7 +144,7 @@ public partial class DerivedException : BaseException
 ### ConvertToInternalError
 
 When the generated code decodes an exception from a payload, it sets the exception's
-[`ConvertToInternalError`][convert-to-internal-error] property to `true`.
+[ConvertToInternalError][convert-to-internal-error] property to `true`.
 
 This way, when the implementation of an operation makes an invocation and this invocation throws an exception, by
 default, this exception is not re-sent as-is but gets converted into a response with status code

--- a/content/slice/language-guide/operation.md
+++ b/content/slice/language-guide/operation.md
@@ -142,7 +142,7 @@ interface FileServer {
 
 {% /slice2 %}
 
-In C# with IceRPC, the generated code sets the [`ICompressFeature`][compress-feature] in the outgoing request features.
+In C# with IceRPC, the generated code sets the [ICompressFeature][compress-feature] in the outgoing request features.
 
 This compression request is typically fulfilled by the compressor interceptor or middleware, which needs to be installed
 in your invocation resp. dispatch pipeline. If you neglect to install this interceptor or middleware, the corresponding


### PR DESCRIPTION
Fix #395