### PR TITLE
Add Protobuf packages

### DIFF
--- a/content/getting-started/installation/existing-project.md
+++ b/content/getting-started/installation/existing-project.md
@@ -22,6 +22,23 @@ The Slice compiler included in `IceRpc.Slice.Tools` generates C# code that depen
 `IceRpc.Slice` packages. You need `IceRpc.Slice.Tools` only during development.
 {% /callout %}
 
+## IceRPC and Protobuf packages
+
+If you plan on using IceRPC together with [Protobuf], add the [IceRpc.Protobuf] and [IceRpc.Protobuf.Tools] packages to
+your project with the following commands:
+
+```shell {% showTitle=false %}
+dotnet add package IceRpc.Protobuf
+dotnet add package IceRpc.Protobuf.Tools
+```
+
+Adding [IceRpc.Protobuf] automatically pulls its dependencies, including the [IceRpc] and [Google.Protobuf] packages.
+
+{% callout %}
+The protoc compiler included in `IceRpc.Protobuf.Tools` generates C# code that depends on the `Google.Protobuf` and
+`IceRpc.Protobuf` packages. You need `IceRpc.Protobuf.Tools` only during development.
+{% /callout %}
+
 ## IceRPC only
 
 If you plan on using IceRPC with JSON, Protobuf, or some other serialization format, add the [IceRpc] package to your
@@ -44,10 +61,14 @@ dotnet add package IceRpc.Transports.Quic
 The full list of IceRPC packages is available on the [next page][full-list].
 
 [full-list]: nuget-packages
-[Slice]: /slice
-[nuget]: https://www.nuget.org/
-[IceRpc]: https://www.nuget.org/packages/IceRpc
-[IceRpc.Slice]: https://www.nuget.org/packages/IceRpc.Slice
+[Google.Protobuf]: https://www.nuget.org/packages/Google.Protobuf
+[IceRpc.Protobuf.Tools]: https://www.nuget.org/packages/IceRpc.Protobuf.Tools
+[IceRpc.Protobuf]: https://www.nuget.org/packages/IceRpc.Protobuf
 [IceRpc.Slice.Tools]: https://www.nuget.org/packages/IceRpc.Slice.Tools
+[IceRpc.Slice]: https://www.nuget.org/packages/IceRpc.Slice
 [IceRpc.Transports.Quic]: https://www.nuget.org/packages/IceRpc.Transports.Quic
+[IceRpc]: https://www.nuget.org/packages/IceRpc
+[nuget]: https://www.nuget.org/
+[Protobuf]: https://protobuf.dev/
+[Slice]: /slice
 [ZeroC.Slice]: https://www.nuget.org/packages/ZeroC.Slice

--- a/content/getting-started/installation/existing-project.md
+++ b/content/getting-started/installation/existing-project.md
@@ -35,8 +35,9 @@ dotnet add package IceRpc.Protobuf.Tools
 Adding [IceRpc.Protobuf] automatically pulls its dependencies, including the [IceRpc] and [Google.Protobuf] packages.
 
 {% callout %}
-The protoc compiler included in `IceRpc.Protobuf.Tools` generates C# code that depends on the `Google.Protobuf` and
-`IceRpc.Protobuf` packages. You need `IceRpc.Protobuf.Tools` only during development.
+The protoc compiler and the protoc-gen-icerpc-csharp generator included in `IceRpc.Protobuf.Tools` generates C# code
+that depends on the `Google.Protobuf` and `IceRpc.Protobuf` packages. You need `IceRpc.Protobuf.Tools` only during
+development.
 {% /callout %}
 
 ## IceRPC only

--- a/content/getting-started/installation/existing-project.md
+++ b/content/getting-started/installation/existing-project.md
@@ -42,8 +42,8 @@ development.
 
 ## IceRPC only
 
-If you plan on using IceRPC with JSON, Protobuf, or some other serialization format, add the [IceRpc] package to your
-project with the following command:
+If you plan on using IceRPC with JSON, or some other serialization format, add the [IceRpc] package to your project with
+the following command:
 
 ```shell {% showTitle=false %}
 dotnet add package IceRpc

--- a/content/getting-started/installation/nuget-packages.md
+++ b/content/getting-started/installation/nuget-packages.md
@@ -3,24 +3,26 @@ title: NuGet packages
 description: A list of all the IceRPC NuGet packages
 ---
 
-| Name                                    | Description                                           |
-| --------------------------------------- | ----------------------------------------------------- |
-| [IceRpc]                                | IceRPC for C# base package                            |
-| [IceRpc.Compressor]                     | Compressor interceptor and middleware                 |
-| [IceRpc.Deadline]                       | Deadline interceptor and middleware                   |
-| [IceRpc.Extensions.DependencyInjection] | Extensions for the Microsoft DI container             |
-| [IceRpc.Locator]                        | Locator interceptor (for [Ice interop])               |
-| [IceRpc.Logger]                         | Logger interceptor and middleware                     |
-| [IceRpc.Metrics]                        | Metrics interceptor and middleware                    |
-| [IceRpc.RequestContext]                 | Request context interceptor and middleware (primarily for Ice interop) |
-| [IceRpc.Retry]                          | Retry interceptor                                     |
-| [IceRpc.Slice]                          | IceRPC + Slice integration library                    |
-| [IceRpc.Slice.Tools]                    | Slice compiler for C# + MSBuild support            |
-| [IceRpc.Telemetry]                      | OpenTelemetry interceptor and middleware              |
-| [IceRpc.Templates]                      | Project templates for IceRPC                          |
-| [IceRpc.Transports.Coloc]               | Coloc duplex transport                                |
-| [IceRpc.Transports.Quic]                | QUIC multiplexed transport                            |
-| [ZeroC.Slice]                           | Slice serialization library                           |
+| Name                                    | Description                                                                             |
+|-----------------------------------------|-----------------------------------------------------------------------------------------|
+| [IceRpc]                                | IceRPC for C# base package                                                              |
+| [IceRpc.Compressor]                     | Compressor interceptor and middleware                                                   |
+| [IceRpc.Deadline]                       | Deadline interceptor and middleware                                                     |
+| [IceRpc.Extensions.DependencyInjection] | Extensions for the Microsoft DI container                                               |
+| [IceRpc.Locator]                        | Locator interceptor (for [Ice interop])                                                 |
+| [IceRpc.Logger]                         | Logger interceptor and middleware                                                       |
+| [IceRpc.Metrics]                        | Metrics interceptor and middleware                                                      |
+| [IceRpc.Protobuf]                       | IceRPC + Protobuf integration library                                                   |
+| [IceRpc.Protobuf.Tools]                 | Protobuf compiler, protoc, and the protoc-gen-icerpc-csharp generator + MSBuild support |
+| [IceRpc.RequestContext]                 | Request context interceptor and middleware (primarily for Ice interop)                  |
+| [IceRpc.Retry]                          | Retry interceptor                                                                       |
+| [IceRpc.Slice]                          | IceRPC + Slice integration library                                                      |
+| [IceRpc.Slice.Tools]                    | Slice compiler for C# + MSBuild support                                                 |
+| [IceRpc.Telemetry]                      | OpenTelemetry interceptor and middleware                                                |
+| [IceRpc.Templates]                      | Project templates for IceRPC                                                            |
+| [IceRpc.Transports.Coloc]               | Coloc duplex transport                                                                  |
+| [IceRpc.Transports.Quic]                | QUIC multiplexed transport                                                              |
+| [ZeroC.Slice]                           | Slice serialization library                                                             |
 
 [Ice interop]: /icerpc-for-ice-users
 [IceRpc]: https://www.nuget.org/packages/IceRpc
@@ -30,6 +32,8 @@ description: A list of all the IceRPC NuGet packages
 [IceRpc.Locator]: https://www.nuget.org/packages/IceRpc.Locator
 [IceRpc.Logger]: https://www.nuget.org/packages/IceRpc.Logger
 [IceRpc.Metrics]: https://www.nuget.org/packages/IceRpc.Metrics
+[IceRpc.Protobuf]: https://www.nuget.org/packages/IceRpc.Protobuf
+[IceRpc.Protobuf.Tools]: https://www.nuget.org/packages/IceRpc.Protobuf.Tools
 [IceRpc.RequestContext]: https://www.nuget.org/packages/IceRpc.RequestContext
 [IceRpc.Retry]: https://www.nuget.org/packages/IceRpc.Retry
 [IceRpc.Slice]: https://www.nuget.org/packages/IceRpc.Slice

--- a/content/getting-started/installation/nuget-packages.md
+++ b/content/getting-started/installation/nuget-packages.md
@@ -13,7 +13,7 @@ description: A list of all the IceRPC NuGet packages
 | [IceRpc.Logger]                         | Logger interceptor and middleware                                                       |
 | [IceRpc.Metrics]                        | Metrics interceptor and middleware                                                      |
 | [IceRpc.Protobuf]                       | IceRPC + Protobuf integration library                                                   |
-| [IceRpc.Protobuf.Tools]                 | Protobuf compiler, protoc, and the protoc-gen-icerpc-csharp generator + MSBuild support |
+| [IceRpc.Protobuf.Tools]                 | Protobuf compiler protoc, and the protoc-gen-icerpc-csharp generator + MSBuild support  |
 | [IceRpc.RequestContext]                 | Request context interceptor and middleware (primarily for Ice interop)                  |
 | [IceRpc.Retry]                          | Retry interceptor                                                                       |
 | [IceRpc.Slice]                          | IceRPC + Slice integration library                                                      |

--- a/content/getting-started/installation/template.md
+++ b/content/getting-started/installation/template.md
@@ -13,12 +13,40 @@ dotnet new install IceRpc.Templates
 
 ## Template list
 
-| Template name            | Description                                                                                                  |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| `icerpc-slice-client`    | A project template for creating an IceRPC + Slice client console application.                                |
-| `icerpc-slice-server`    | A project template for creating an IceRPC + Slice server console application.                                |
-| `icerpc-slice-di-client` | A project template for creating an IceRPC + Slice client console application using Microsoft's DI container. |
-| `icerpc-slice-di-server` | A project template for creating an IceRPC + Slice server console application using Microsoft's DI container. |
+| Template name               | Description                                                                                                     |
+|-----------------------------|-----------------------------------------------------------------------------------------------------------------|
+| `icerpc-protobuf-client`    | A project template for creating an IceRPC + Protobuf client console application.                                |
+| `icerpc-protobuf-server`    | A project template for creating an IceRPC + Protobuf server console application.                                |
+| `icerpc-protobuf-di-client` | A project template for creating an IceRPC + Protobuf client console application using Microsoft's DI container. |
+| `icerpc-protobuf-di-server` | A project template for creating an IceRPC + Protobuf server console application using Microsoft's DI container. |
+| `icerpc-slice-client`       | A project template for creating an IceRPC + Slice client console application.                                   |
+| `icerpc-slice-server`       | A project template for creating an IceRPC + Slice server console application.                                   |
+| `icerpc-slice-di-client`    | A project template for creating an IceRPC + Slice client console application using Microsoft's DI container.    |
+| `icerpc-slice-di-server`    | A project template for creating an IceRPC + Slice server console application using Microsoft's DI container.    |
+
+#### Create a client application (IceRPC + Protobuf)
+
+```shell {% showTitle=false %}
+dotnet new icerpc-protobuf-client -o MyClient
+```
+
+#### Create a server application (IceRPC + Protobuf)
+
+```shell {% showTitle=false %}
+dotnet new icerpc-protobuf-server -o MyServer
+```
+
+#### Create a client application (IceRPC + Protobuf and DI)
+
+```shell {% showTitle=false %}
+dotnet new icerpc-protobuf-di-client -o MyClient
+```
+
+#### Create a server application (IceRPC + Protobuf and DI)
+
+```shell {% showTitle=false %}
+dotnet new icerpc-protobuf-di-server -o MyServer
+```
 
 #### Create a client application (IceRPC + Slice)
 


### PR DESCRIPTION
Add Protobuf packages to `installation/existing-project.md`, `installation/nuget-packages.md`, and `installation/template.md` pages.