### PR TITLE
Updates for default service path

### DIFF
--- a/content/getting-started/icerpc-protobuf-tutorial/server-tutorial.md
+++ b/content/getting-started/icerpc-protobuf-tutorial/server-tutorial.md
@@ -136,11 +136,11 @@ This router corresponds to our [dispatch pipeline][dispatch-pipeline]: when we
 receive a request, we first give it to the [Logger] middleware, then to the
 [Deadline] middleware and finally we route this request based on its path.
 
-The `Map` call means if the request's path is the default path for Slice
+The `Map` call means if the request's path is the default service path for Slice
 interface `Greeter`, route it to the `Chatbot` instance. Otherwise, the router
 returns a response with status code [NotFound].
 
-The default path for `Greeter` is `/visitor_center.Greeter` (it uses the Protobuf
+The default service path for `Greeter` is `/visitor_center.Greeter` (it uses the Protobuf
 package name and service name). The `Map` call above is a shortcut for:
 
 ```csharp

--- a/content/getting-started/icerpc-slice-tutorial/server-tutorial.md
+++ b/content/getting-started/icerpc-slice-tutorial/server-tutorial.md
@@ -125,11 +125,11 @@ This router corresponds to our [dispatch pipeline][dispatch-pipeline]: when we
 receive a request, we first give it to the [Logger] middleware, then to the
 [Deadline] middleware and finally we route this request based on its path.
 
-The `Map` call means if the request's path is the default path for Slice
+The `Map` call means if the request's path is the default service path for Slice
 interface `Greeter`, route it to the `Chatbot` instance. Otherwise, the router
 returns a response with status code [NotFound].
 
-The default path for `Greeter` is `/VisitorCenter.Greeter` (it uses the Slice
+The default service path for `Greeter` is `/VisitorCenter.Greeter` (it uses the Slice
 module name and interface name). The `Map` call above is a shortcut for:
 
 ```csharp

--- a/content/protobuf/language-mapping/service.md
+++ b/content/protobuf/language-mapping/service.md
@@ -115,12 +115,12 @@ The `invoker` parameter represents your [invocation pipeline](/icerpc/invocation
 [address](/icerpc/invocation/service-address) of the remote service, and the `encodeOptions` parameter allows
 you to customize the encoding of your Protobuf messages. See [ProtobufEncodeOptions] for details.
 
-A `null` service address is equivalent to an icerpc service address with the default path of the associated Protobuf
-service.
+A `null` service address is equivalent to an icerpc service address with the default service path of the associated
+Protobuf service.
 
 {% callout type="note" %}
-The default path of a Protobuf service is `/` followed by its fully qualified name. For example, the default path of
-Protobuf service `visitor_center.Greeter` is `/visitor_center.Greeter`.
+The default service path of a Protobuf service is `/` followed by its fully qualified name. For example, the default
+service path of Protobuf service `visitor_center.Greeter` is `/visitor_center.Greeter`.
 {% /callout %}
 
 ### I*Name*Service

--- a/content/slice/language-guide/interface.md
+++ b/content/slice/language-guide/interface.md
@@ -29,8 +29,8 @@ implement the C# (or Rust, Python...) abstractions and concrete implementations 
 your Slice interfaces.
 
 {% callout %}
-An interface is a Slice construct but not a Slice type. This means you cannot use an interface as the type of a
-Slice field or operation parameter.
+An interface is a Slice construct but not a Slice type. This means you cannot use an interface as the type of a Slice
+field or operation parameter.
 {% /callout %}
 
 ## Interface inheritance
@@ -156,14 +156,19 @@ The `invoker` parameter represents your [invocation pipeline](/icerpc/invocation
 you to customize the Slice encoding of operation parameters. See
 [SliceEncodeOptions] for details.
 
-A `null` service address is equivalent to an icerpc service address with the default path of the associated Slice
-interface.
+A `null` service address is equivalent to an icerpc service address with the default service path of the associated
+Slice interface.
 
-{% callout type="note" %}
-The default path of a Slice interface is `/` followed by its fully qualified name with `::` replaced by `.`.
+The default service path of a Slice interface is `/` followed by its fully qualified name with `::` replaced by `.`. For
+example, the default service path of Slice interface `VisitorCenter::Greeter` is `/VisitorCenter.Greeter`. It's also
+available as the constant `DefaultServicePath` in the generated proxy struct:
 
-For example, the default path of Slice interface `VisitorCenter::Greeter` is `/VisitorCenter.Greeter`.
-{% /callout %}
+```csharp
+public readonly partial record struct WidgetProxy : IWidget, IProxy
+{
+    public const string DefaultServicePath = "/Example/Widget";
+}
+```
 
 {% slice2 %}
 If you want to create a [relative proxy], call the `FromPath` static method:
@@ -175,7 +180,13 @@ public readonly partial record struct WidgetProxy : IWidget, IProxy
 }
 ```
 
-The proxy struct also provides a parameterless constructor that creates a relative proxy with the default path.
+For example, if you want to create a relative proxy with the default service path, call:
+
+```csharp
+// Creates a relative proxy with the default service path and an invalid invoker.
+var relativeProxy = WidgetProxy.FromPath(WidgetProxy.DefaultServicePath);
+```
+
 {% /slice2 %}
 
 When a Slice interface derives from another interface, its proxy struct provides an implicit conversion operator to be

--- a/content/slice/language-guide/interface.md
+++ b/content/slice/language-guide/interface.md
@@ -89,7 +89,8 @@ public partial interface IWidget
     Task SpinAsync(
         int speed,
         IFeatureCollection? features = null,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken =
+            default);
 }
 ```
 
@@ -188,6 +189,18 @@ var relativeProxy = WidgetProxy.FromPath(WidgetProxy.DefaultServicePath);
 ```
 
 {% /slice2 %}
+
+The generated proxy struct also provides a parameterless constructor that initializes the proxy's service address to
+an icerpc service address with the default service path. If you call this constructor directly, you also need to
+initialize the invoker, for example:
+
+```csharp
+// Calls WidgetProxy's parameterless constructor
+var proxy = new WidgetProxy { Invoker = connection };
+
+// The above is equivalent to:
+var proxy = new WidgetPRoxy(connection);
+```
 
 When a Slice interface derives from another interface, its proxy struct provides an implicit conversion operator to be
 base interface. For example:
@@ -291,9 +304,10 @@ interface Counter {
 ```
 
 ```csharp
-// A service class that implements 2 Slice interfaces
+// Implements two Slice interfaces
 [SliceService]
-internal partial class MyWidget : IWidgetService, ICounterService
+internal partial class MyWidget : IWidgetService,
+                                  ICounterService
 {
     // implements SpinAsync and GetCountAsync.
 }


### PR DESCRIPTION
This PR renames "default path" to "default service path" in the text, shows the DefaultServicePath constant (C#) and fixes the incorrect documentation of the parameterless proxy constructor.
