### PR TITLE
Replace public by internal in Slice-to-C# mapping

### DIFF
--- a/content/icerpc/dispatch/middleware.md
+++ b/content/icerpc/dispatch/middleware.md
@@ -21,11 +21,9 @@ than `Ok`).
 For example, a simple C# middleware could look like:
 
 ```csharp
-public class SimpleMiddleware : IDispatcher
+internal class SimpleMiddleware : IDispatcher
 {
     private readonly IDispatcher _next;
-
-    public SimpleMiddleware(IDispatcher next) => _next = next;
 
     public async ValueTask<OutgoingResponse> DispatchAsync(
         IncomingRequest request,
@@ -36,6 +34,8 @@ public class SimpleMiddleware : IDispatcher
         Console.WriteLine($"after _next.DispatchAsync; the response status code is {response.StatusCode}");
         return response;
     }
+
+    internal SimpleMiddleware(IDispatcher next) => _next = next;
 }
 ```
 

--- a/content/icerpc/invocation/interceptor.md
+++ b/content/icerpc/invocation/interceptor.md
@@ -28,7 +28,7 @@ internal class SimpleInterceptor : IInvoker
     {
         Console.WriteLine("before _next.InvokeAsync");
         IncomingResponse response = await _next.InvokeAsync(request, cancellationToken);
-        Console.WriteLine($"after _next.InvokerAsync; the response status code is {response.StatusCode}");
+        Console.WriteLine($"after _next.InvokeAsync; the response status code is {response.StatusCode}");
         return response;
     }
 

--- a/content/icerpc/invocation/interceptor.md
+++ b/content/icerpc/invocation/interceptor.md
@@ -20,11 +20,9 @@ invocation pipeline returning a cached response or throwing an exception.
 For example, a simple C# interceptor could look like:
 
 ```csharp
-public class SimpleInterceptor : IInvoker
+internal class SimpleInterceptor : IInvoker
 {
     private readonly IInvoker _next;
-
-    public SimpleInterceptor(IInvoker next) => _next = next;
 
     public async Task<IncomingResponse> InvokeAsync(OutgoingRequest request, CancellationToken cancellationToken)
     {
@@ -33,6 +31,8 @@ public class SimpleInterceptor : IInvoker
         Console.WriteLine($"after _next.InvokerAsync; the response status code is {response.StatusCode}");
         return response;
     }
+
+    internal SimpleInterceptor(IInvoker next) => _next = next;
 }
 ```
 

--- a/content/slice/basics/contract-first.md
+++ b/content/slice/basics/contract-first.md
@@ -46,7 +46,7 @@ includes a method per Slice operation. The generated service interface for the `
 // generated code
 namespace VisitorCenter;
 
-public partial interface IGreeterService
+internal partial interface IGreeterService
 {
     ValueTask<string> GreetAsync(string name, IFeatureCollection features, CancellationToken cancellationToken);
 }
@@ -97,7 +97,7 @@ The generated interface for our `Greeter` Slice interface is:
 // generated code
 namespace VisitorCenter;
 
-public partial interface IGreeter
+internal partial interface IGreeter
 {
     Task<string> GreetAsync(
         string name,

--- a/content/slice/index.md
+++ b/content/slice/index.md
@@ -66,7 +66,7 @@ For example, the Slice compiler for C# generates two C# interfaces and a struct 
 earlier:
 
 ```csharp {% title="C# generated code - client-side" %}
-public partial interface IGreeter
+internal partial interface IGreeter
 {
    Task<string> GreetAsync(
       string name,
@@ -74,7 +74,7 @@ public partial interface IGreeter
       CancellationToken cancellationToken = default);
 }
 
-public readonly partial record struct GreeterProxy : IGreeter, IProxy
+internal readonly partial record struct GreeterProxy : IGreeter, IProxy
 {
    public Task<string> GreetAsync(
       string name,
@@ -87,7 +87,7 @@ public readonly partial record struct GreeterProxy : IGreeter, IProxy
 ```
 
 ```csharp {% title="C# generated code - server-side" %}
-public partial interface IGreeterService
+internal partial interface IGreeterService
 {
    ValueTask<string> GreetAsync(
       string name,

--- a/content/slice/language-guide/attributes.md
+++ b/content/slice/language-guide/attributes.md
@@ -102,8 +102,8 @@ The following attributes are specific to the C# mapping. They all start with the
 | [`cs::attribute`][cs-attribute-attribute]     | Enum types, enumerators, and fields                                                          | Add the specified C# attribute to the mapped C# enum, enum member, or field. |
 | [`cs::encodeReturn`][cs-encoded-return]       | Operations                                                                                   | Return an already encoded return value (server-side only).                   |
 | [`cs::identifier`](#cs::identifier-attribute) | Interfaces, operations, parameters, user-defined types, fields, and enumerators              | Change the name of the mapped C# identifier.                                 |
-| [`cs::internal`](#cs::internal-attribute)     | Interfaces and user-defined types                                                            | Map to an internal C# type instead of a public C# type.                      |
 | [`cs::namespace`][cs-namespace]               | Modules                                                                                      | Change the name of the mapped C# namespace.                                  |
+| [`cs::public`](#cs::public-attribute)         | Interfaces and user-defined types                                                            | Map to a public C# type instead of an internal C# type.                      |
 | [`cs::readonly`][cs-readonly]                 | Structs and struct fields                                                                    | Adds `readonly` to the mapped C# struct or field.                            |
 | `cs::type`                                    | [Custom types][custom-type], [sequences][sequence-type], and [dictionaries][dictionary-type] | Specify the mapped C# type.                                                  |
 
@@ -124,12 +124,12 @@ interface Enumerator {
 ```
 
 ```csharp
-public partial interface IRemoteEnumerator
+internal partial interface IRemoteEnumerator
 {
     ...
 }
 
-public readonly partial
+internal readonly partial
 record struct RemoteEnumeratorProxy :
     IRemoteEnumerator,
     IProxy
@@ -137,7 +137,7 @@ record struct RemoteEnumeratorProxy :
     ...
 }
 
-public partial interface IRemoteEnumeratorService
+internal partial interface IRemoteEnumeratorService
 {
     ...
 }
@@ -145,9 +145,9 @@ public partial interface IRemoteEnumeratorService
 
 {% /aside %}
 
-### cs::internal attribute
+### cs::public attribute
 
-The `cs::internal` attribute maps a Slice type to one or more internal C# types. It does not accept any argument.
+The `cs::public` attribute maps a Slice type to one or more public C# types. It does not accept any argument.
 
 [compress]: operation#compress-attribute
 [cs-attribute-attribute]: enum-types#cs::attribute-attribute
@@ -158,4 +158,3 @@ The `cs::internal` attribute maps a Slice type to one or more internal C# types.
 [dictionary-type]: dictionary-types#cs::type-attribute
 [oneway]: operation#oneway-attribute
 [sequence-type]: sequence-types#cs::type-attribute
-

--- a/content/slice/language-guide/custom-types.md
+++ b/content/slice/language-guide/custom-types.md
@@ -52,6 +52,7 @@ public static class BigIntSliceEncoderExtensions
     public static void EncodeBigInt(this ref SliceEncoder encoder, Int128 value) { ... your implementation ... }
 }
 ```
+
 {% callout type="note" %}
 A more logical name for this custom type would be `Int128`. We picked `BigInt` to make it clear where the Slice
 identifier is used in the classes and methods that encode/decode this custom type.

--- a/content/slice/language-guide/dictionary-types.md
+++ b/content/slice/language-guide/dictionary-types.md
@@ -58,7 +58,7 @@ struct DictionaryExample {
 internal partial record struct DictionaryExample
 {
     internal IDictionary<
-        int32,
+        int,
         IDictionary<string, double>> X;
 
     internal IDictionary<string, double?> Y;

--- a/content/slice/language-guide/dictionary-types.md
+++ b/content/slice/language-guide/dictionary-types.md
@@ -55,13 +55,13 @@ struct DictionaryExample {
 ```
 
 ```csharp
-public partial record struct DictionaryExample
+internal partial record struct DictionaryExample
 {
-    public IDictionary<
+    internal IDictionary<
         int32,
         IDictionary<string, double>> X;
 
-    public IDictionary<string, double?> Y;
+    internal IDictionary<string, double?> Y;
 }
 ```
 
@@ -109,7 +109,7 @@ interface Greeter {
 ```
 
 ```csharp
-public partial interface IGreeter
+internal partial interface IGreeter
 {
     Task<List<KeyValuePair<string, string>>>
     AllPreviousGreetingsAsync(
@@ -117,7 +117,7 @@ public partial interface IGreeter
         CancellationToken cancellationToken = default);
 }
 
-public partial interface IGreeterService
+internal partial interface IGreeterService
 {
     ValueTask<IEnumerable<KeyValuePair<string, string>>>
     AllPreviousGreetingsAsync(

--- a/content/slice/language-guide/enum-types.md
+++ b/content/slice/language-guide/enum-types.md
@@ -129,7 +129,7 @@ unchecked enum with fields.
 
 ### Enum with underlying type in C\#
 
-An enum with underlying type maps to a C# enumeration with the same name, and each Slice enumerator maps to a
+An enum with underlying type maps to an internal C# enumeration with the same name, and each Slice enumerator maps to a
 C# enumerator with the same name. For example:
 
 {% aside alignment="top" %}
@@ -241,10 +241,9 @@ unchecked enum Shape {
 
 maps to:
 
-
 ```csharp
 [Dunet.Union]
-internal partial abstract record class Shape
+internal abstract partial record class Shape
 {
     public partial record Circle(uint Radius) : Shape;
 

--- a/content/slice/language-guide/enum-types.md
+++ b/content/slice/language-guide/enum-types.md
@@ -129,7 +129,7 @@ unchecked enum with fields.
 
 ### Enum with underlying type in C\#
 
-An enum with underlying type maps to a public C# enumeration with the same name, and each Slice enumerator maps to a
+An enum with underlying type maps to a C# enumeration with the same name, and each Slice enumerator maps to a
 C# enumerator with the same name. For example:
 
 {% aside alignment="top" %}
@@ -139,7 +139,7 @@ enum Fruit : uint8 { Apple, Pear, Orange }
 ```
 
 ```csharp
-public enum Fruit : uint8
+internal enum Fruit : uint8
 {
     Apple = 0,
     Pear = 1,
@@ -164,8 +164,6 @@ generator to generate additional helper code for these partial records.
 
 For example:
 
-{% aside alignment="top" %}
-
 ```slice
 enum Shape {
     Circle(radius: uint32)
@@ -174,21 +172,19 @@ enum Shape {
 }
 ```
 
+maps to:
+
 ```csharp
 [Dunet.Union]
-public partial abstract record class Shape
+internal abstract partial record class Shape
 {
-    partial record Circle(uint Radius) : Shape;
+    public partial record Circle(uint Radius) : Shape;
 
-    partial record Rectangle(
-        uint Width,
-        uint Length) : Shape;
+    public partial record Rectangle(uint Width, uint Length) : Shape;
 
-    partial record Dot : Shape;
+    public partial record Dot : Shape;
 }
 ```
-
-{% /aside %}
 
 {% callout %}
 [ZeroC.Slice] has a dependency on the [Dunet package]; as a result, you don't need an explicit reference to Dunet in
@@ -205,14 +201,14 @@ The Slice compiler generates extension methods to encode and decode instances of
 With our `Fruit` example, we get:
 
 ```csharp
-public static class FruitSliceEncoderExtensions
+internal static class FruitSliceEncoderExtensions
 {
-    public static void EncodeFruit(this ref SliceEncoder encoder, Fruit value) => ...
+    internal static void EncodeFruit(this ref SliceEncoder encoder, Fruit value) => ...
 }
 
-public static class FruitSliceDecoderExtensions
+internal static class FruitSliceDecoderExtensions
 {
-    public static Fruit DecodeFruit(this ref SliceDecoder decoder) => ...
+    internal static Fruit DecodeFruit(this ref SliceDecoder decoder) => ...
 }
 ```
 
@@ -222,9 +218,9 @@ of the underlying type into an enumerator.
 With our Fruit example:
 
 ```csharp
-public static class FruitByteExtensions
+internal static class FruitByteExtensions
 {
-    public static Fruit AsFruit(this byte value) => ...
+    internal static Fruit AsFruit(this byte value) => ...
 }
 ```
 
@@ -236,8 +232,6 @@ This conversion fails and throws [InvalidDataException] when the value does not 
 The mapped C# API for checked and unchecked enums is the same, with one exception: the mapping for an unchecked enum
 with fields has an additional nested record class named `Unknown` that holds unknown enumerator values. For example:
 
-{% aside alignment="top" %}
-
 ```slice
 unchecked enum Shape {
     Circle(radius: uint32)
@@ -245,25 +239,24 @@ unchecked enum Shape {
 }
 ```
 
+maps to:
+
+
 ```csharp
 [Dunet.Union]
-public partial record class Shape
+internal partial abstract record class Shape
 {
-    partial record Circle(uint Radius) : Shape;
+    public partial record Circle(uint Radius) : Shape;
 
-    partial record Dot : Shape;
+    public partial record Dot : Shape;
 
-    // Extra "enumerator" when mapping an
-    // unchecked enum with fields
-    partial record Unknown(
-        int Discriminant,
-        ReadOnlyMemory<byte> Fields) : Shape;
+    // Extra "enumerator" when mapping an unchecked enum with fields
+    public partial record Unknown(int Discriminant, ReadOnlyMemory<byte> Fields) : Shape;
 }
 ```
 
-{% /aside %}
-
 This `Unknown` enumerator can be re-encoded later without losing any information.
+
 ### cs::attribute attribute
 
 The `cs::attribute` [attribute](attributes) adds the specified C# attribute to the mapped C# enum. You typically use it
@@ -283,7 +276,7 @@ enum MultiHue : uint8 {
 
 ```csharp
 [Flags]
-public enum MultiHue : byte
+internal enum MultiHue : byte
 {
     None = 0,
     Black = 1,

--- a/content/slice/language-guide/enum-types.md
+++ b/content/slice/language-guide/enum-types.md
@@ -139,7 +139,7 @@ enum Fruit : uint8 { Apple, Pear, Orange }
 ```
 
 ```csharp
-internal enum Fruit : uint8
+internal enum Fruit : byte
 {
     Apple = 0,
     Pear = 1,

--- a/content/slice/language-guide/interface.md
+++ b/content/slice/language-guide/interface.md
@@ -83,7 +83,7 @@ interface Widget {
 ```csharp
 namespace Example;
 
-public partial interface IWidget
+internal partial interface IWidget
 {
     // One method per operation
     Task SpinAsync(
@@ -111,7 +111,7 @@ maps to:
 ```csharp
 namespace Draw;
 
-public partial interface IRectangle : IShape, IFillable
+internal partial interface IRectangle : IShape, IFillable
 {
     Task ResizeAsync(
         int x,
@@ -131,9 +131,9 @@ for this service.
 In order to call a remote service, you need to construct a proxy struct using one of its "invoker" constructors:
 
 ```csharp
-public readonly partial record struct WidgetProxy : IWidget, IProxy
+internal readonly partial record struct WidgetProxy : IWidget, IProxy
 {
-    public WidgetProxy(
+    internal WidgetProxy(
         IInvoker invoker,
         ServiceAddress? serviceAddress = null,
         SliceEncodeOptions? encodeOptions = null)
@@ -141,7 +141,7 @@ public readonly partial record struct WidgetProxy : IWidget, IProxy
         ...
     }
 
-    public WidgetProxy(
+    internal WidgetProxy(
         IInvoker invoker,
         System.Uri serviceAddressUri,
         SliceEncodeOptions? encodeOptions = null)
@@ -165,17 +165,18 @@ example, the default service path of Slice interface `VisitorCenter::Greeter` is
 available as the constant `DefaultServicePath` in the generated proxy struct:
 
 ```csharp
-public readonly partial record struct WidgetProxy : IWidget, IProxy
+internal readonly partial record struct WidgetProxy : IWidget, IProxy
 {
-    public const string DefaultServicePath = "/Example/Widget";
+    internal const string DefaultServicePath = "/Example/Widget";
 }
 ```
+
 If you want to create a [relative proxy], call the `FromPath` static method:
 
 ```csharp
-public readonly partial record struct WidgetProxy : IWidget, IProxy
+internal readonly partial record struct WidgetProxy : IWidget, IProxy
 {
-    public static WidgetProxy FromPath(string path) { ... }
+    internal static WidgetProxy FromPath(string path) { ... }
 }
 ```
 
@@ -214,14 +215,14 @@ maps to:
 ```csharp
 namespace Draw;
 
-public readonly partial record struct RectangleProxy : IRectangle, IProxy
+internal readonly partial record struct RectangleProxy : IRectangle, IProxy
 {
-    public static implicit operator ShapeProxy(RectangleProxy proxy)
+    internal static implicit operator ShapeProxy(RectangleProxy proxy)
     {
         ...
     }
 
-    public static implicit operator FillableProxy(RectangleProxy proxy)
+    internal static implicit operator FillableProxy(RectangleProxy proxy)
     {
         ...
     }
@@ -258,7 +259,7 @@ interface Widget {
 namespace Example;
 
 // Generated code
-public partial interface IWidgetService
+internal partial interface IWidgetService
 {
     // One method per operation
     ValueTask SpinAsync(

--- a/content/slice/language-guide/operation.md
+++ b/content/slice/language-guide/operation.md
@@ -127,6 +127,7 @@ interface Logger {
     [oneway] logMessage(message: string)
 }
 ```
+
 ## C# mapping {% icerpcSlice=true %}
 
 A Slice operation named *opName* in interface `Greeter` is mapped to abstract method *OpName*Async in the interface
@@ -151,7 +152,7 @@ interface Greeter {
 ```csharp
 namespace VisitorCenter;
 
-public partial interface IGreeter
+internal partial interface IGreeter
 {
     Task<string> GreetAsync(
         string name,
@@ -159,7 +160,7 @@ public partial interface IGreeter
         CancellationToken cancellationToken = default);
 }
 
-public partial interface IGreeterService
+internal partial interface IGreeterService
 {
     ValueTask<string> GreetAsync(
         string name,
@@ -195,21 +196,21 @@ interface Greeter {
 produces 4 helper methods:
 
 ```csharp
-public readonly partial record struct GreeterProxy : IGreeter, IProxy
+internal readonly partial record struct GreeterProxy : IGreeter, IProxy
 {
-    public static class Request
+    internal static class Request
     {
         // Encodes the name argument into a request payload (a PipeReader).
-        public static PipeReader EncodeGreet(string name, SliceEncodeOptions? encodeOptions = null)
+        internal static PipeReader EncodeGreet(string name, SliceEncodeOptions? encodeOptions = null)
         {
             ...
         }
     }
 
-    public static class Response
+    internal static class Response
     {
         // Decodes the response payload into a string (the greeting).
-        public static ValueTask<string> DecodeGreetAsync(
+        internal static ValueTask<string> DecodeGreetAsync(
             IncomingResponse response,
             OutgoingRequest request,
             IProxy sender,
@@ -220,12 +221,12 @@ public readonly partial record struct GreeterProxy : IGreeter, IProxy
     }
 }
 
-public partial interface IGreeterService
+internal partial interface IGreeterService
 {
-    public static class Request
+    internal static class Request
     {
         // Decodes the name argument from the request payload.
-        public static ValueTask<string> DecodeGreetAsync(
+        internal static ValueTask<string> DecodeGreetAsync(
             IncomingRequest request,
             CancellationToken cancellationToken)
         {
@@ -233,16 +234,17 @@ public partial interface IGreeterService
         }
     }
 
-    public static class Response
+    internal static class Response
     {
         // Encodes the greeting return value into a response payload.
-        public static PipeReader EncodeGreet(string returnValue, SliceEncodeOptions? encodeOptions = null)
+        internal static PipeReader EncodeGreet(string returnValue, SliceEncodeOptions? encodeOptions = null)
         {
             ...
         }
     }
 }
 ```
+
 {% callout type="note" %}
 If your operation has a stream parameter, the encode helper (in *NameProxy*.Request) does not encode the stream
 argument; however, the decode helper (in I*Name*Service.Request) decodes all arguments, including the stream.

--- a/content/slice/language-guide/parameters.md
+++ b/content/slice/language-guide/parameters.md
@@ -77,7 +77,7 @@ interface ImageStore {
 ```
 
 ```csharp
-public partial interface IImageStore
+internal partial interface IImageStore
 {
     Task UploadImageAsync(
         string name,
@@ -108,7 +108,7 @@ interface TemperatureProbe {
 ```
 
 ```csharp
-public partial interface ITemperatureProbe
+internal partial interface ITemperatureProbe
 {
     Task<IAsyncEnumerable<float>> ReadAsync(
         IFeatureCollection? features = null,

--- a/content/slice/language-guide/sequence-types.md
+++ b/content/slice/language-guide/sequence-types.md
@@ -50,11 +50,11 @@ struct SequenceExample {
 ```
 
 ```csharp
-public partial record struct SequenceExample
+internal partial record struct SequenceExample
 {
-    public IList<IList<string>> X;
+    internal IList<IList<string>> X;
 
-    public IList<int?> Y;
+    internal IList<int?> Y;
 }
 ```
 
@@ -121,7 +121,7 @@ compact struct Widget { ... }
 ```
 
 ```csharp
-public partial interface IWidgetCatalog
+internal partial interface IWidgetCatalog
 {
     Task<HashSet<Widget>> GetWidgetsAsync(
         string prefix,
@@ -129,7 +129,7 @@ public partial interface IWidgetCatalog
         CancellationToken cancellationToken = default);
 }
 
-public partial interface IWidgetCatalogService
+internal partial interface IWidgetCatalogService
 {
     ValueTask<IEnumerable<Widget>> GetWidgetsAsync(
         string prefix,

--- a/content/slice/language-guide/struct-types.md
+++ b/content/slice/language-guide/struct-types.md
@@ -39,7 +39,7 @@ The encoding of a compact struct is slightly more compact than the encoding of a
 byte per instance.
 ## C# mapping
 
-A Slice struct maps to a public C# record struct with the same name. For example:
+A Slice struct maps to a C# record struct with the same name. For example:
 {% aside alignment="top" %}
 
 ```slice
@@ -55,18 +55,18 @@ struct PostalAddress {
 ```
 
 ```csharp
-public partial record struct PostalAddress
+internal partial record struct PostalAddress
 {
-    public required string RecipientFullName { get; set; }
-    public required string StreetAddress1 { get; set; }
-    public string? StreetAddress2 { get; set; }
-    public string? StreetAddress3 { get; set; }
-    public required string City { get; set; }
-    public StateAbbreviation State { get; set; }
-    public required string Zip { get; set; }
+    internal required string RecipientFullName { get; set; }
+    internal required string StreetAddress1 { get; set; }
+    internal string? StreetAddress2 { get; set; }
+    internal string? StreetAddress3 { get; set; }
+    internal required string City { get; set; }
+    internal StateAbbreviation State { get; set; }
+    internal required string Zip { get; set; }
 
     // Primary constructor.
-    public PostalAddress(
+    internal PostalAddress(
         string recipientFullName,
         string streetAddress1,
         string? streetAddress2,
@@ -85,14 +85,13 @@ public partial record struct PostalAddress
     }
 
     // Decoding constructor.
-    public PostalAddress(ref SliceDecoder decoder)
+    internal PostalAddress(ref SliceDecoder decoder)
     {
         ...
     }
 
     // Encodes this struct.
-    public readonly void Encode(
-        ref SliceEncoder encoder)
+    internal readonly void Encode(ref SliceEncoder encoder)
     {
         ...
     }
@@ -117,10 +116,10 @@ compact struct Point { x: int32, y: int32 }
 ```
 
 ```csharp
-public readonly partial record struct Point
+internal readonly partial record struct Point
 {
-    public int X { get; init; }
-    public int Y { get; init; }
+    internal int X { get; init; }
+    internal int Y { get; init; }
 
     ...
 }

--- a/content/slice/language-guide/struct-types.md
+++ b/content/slice/language-guide/struct-types.md
@@ -8,7 +8,7 @@ description: Learn how to define and use structs in Slice.
 A struct is a user-defined type that holds a list of [fields](fields). For example:
 
 ```slice
-enum StateAbbreviation : uint8 { AL, AK, AZ, AR, AS ... WY }
+enum StateAbbreviation : uint8 { AL, AK, AZ, AR, AS, WY }
 
 struct PostalAddress {
     recipientFullName: string
@@ -37,9 +37,11 @@ compact struct BytePair { first: uint8, second: uint8 }
 
 The encoding of a compact struct is slightly more compact than the encoding of a regular struct: `compact` saves one
 byte per instance.
+
 ## C# mapping
 
-A Slice struct maps to a C# record struct with the same name. For example:
+A Slice struct maps to an internal C# record struct with the same name. For example:
+
 {% aside alignment="top" %}
 
 ```slice
@@ -66,6 +68,7 @@ internal partial record struct PostalAddress
     internal required string Zip { get; set; }
 
     // Primary constructor.
+    [SetRequiredMembers]
     internal PostalAddress(
         string recipientFullName,
         string streetAddress1,
@@ -99,6 +102,7 @@ internal partial record struct PostalAddress
 ```
 
 {% /aside %}
+
 The mapped C# record struct provides a primary constructor with parameters for all its fields, and also a decoding
 constructor that constructs a new instance by decoding its fields from a [SliceDecoder]. The generated `Encode` method
 encodes the struct fields with a [SliceEncoder].

--- a/content/slice/language-guide/struct-types.md
+++ b/content/slice/language-guide/struct-types.md
@@ -68,7 +68,7 @@ internal partial record struct PostalAddress
     internal required string Zip { get; set; }
 
     // Primary constructor.
-    [SetRequiredMembers]
+    [SetsRequiredMembers]
     internal PostalAddress(
         string recipientFullName,
         string streetAddress1,


### PR DESCRIPTION
The default Slice-to-C# mapping is now internal.