### PR TITLE
Fix connection/transport reference pages for QUIC default (0.6)

### DIFF
--- a/content/icerpc/connection/security-with-tls.md
+++ b/content/icerpc/connection/security-with-tls.md
@@ -32,13 +32,20 @@ In C#, you need to specify TLS configuration—in particular a X.509 certificate
 example:
 
 ```csharp
-// SslServerAuthenticationOptions is required with QuicServerTransport.
+using X509Certificate2 serverCertificate = X509CertificateLoader.LoadPkcs12FromFile(
+    "server.p12", password: null, keyStorageFlags: X509KeyStorageFlags.Exportable);
+
+// SslServerAuthenticationOptions is a standard .NET type (System.Net.Security).
+var serverAuthenticationOptions = new SslServerAuthenticationOptions
+{
+    ServerCertificateContext = SslStreamCertificateContext.Create(
+        serverCertificate,
+        additionalCertificates: null)
+};
+
 await using var server = new Server(
     new Chatbot(),
-    new SslServerAuthenticationOptions
-    {
-        ServerCertificate = new X509Certificate2("server.p12")
-    },
+    serverAuthenticationOptions,
     multiplexedServerTransport: new QuicServerTransport());
 ```
 
@@ -50,13 +57,13 @@ tcp, the connection will use TLS. If you don't specify TLS configuration, the co
 In C#, this client-side TLS configuration is provided by a [SslClientAuthenticationOptions] parameter. For example:
 
 ```csharp
-// The default multiplexed transport for icerpc is tcp (implemented by SlicClientTransport over TcpClientTransport).
+// We select the tcp transport (Slic over TCP) with ?transport=tcp, since the default transport is quic.
 // This connection does not use TLS since we don't pass a SslClientAuthenticationOptions parameter.
-await using var plainTcpConnection = new ClientConnection("icerpc://hello.zeroc.com");
+await using var plainTcpConnection = new ClientConnection("icerpc://hello.zeroc.com?transport=tcp");
 
 // We pass a non-null SslClientAuthenticationOptions so the connection uses TLS.
 await using var secureTcpConnection = new ClientConnection(
-    "icerpc://hello.zeroc.com",
+    "icerpc://hello.zeroc.com?transport=tcp",
     new SslClientAuthenticationOptions());
 ```
 
@@ -107,7 +114,7 @@ get an error.
 // Does not work: can't get a TLS connection with a transport that doesn't support TLS.
 await using var connection = new ClientConnection(
     "icerpc://colochost",
-    new SslClientAuthenticationOptions()
+    new SslClientAuthenticationOptions(),
     multiplexedClientTransport: new SlicClientTransport(colocClientTransport));
 ```
 

--- a/content/icerpc/connection/server-address.md
+++ b/content/icerpc/connection/server-address.md
@@ -34,6 +34,9 @@ For example:
 | `icerpc://192.168.100.10:10000?transport=quic` | Connect to `192.168.100.10` on port 10000 using the icerpc protocol over QUIC.                       |
 | `ice://hello.zeroc.com`             | Connect to `hello.zeroc.com` on port 4061 using the ice protocol.                                               |
 
+When you omit the `transport` parameter from an `icerpc` server address, the client connection uses the default
+multiplexed transport, QUIC. To use Slic over TCP instead, add `?transport=tcp` to the server address.
+
 ## Server configuration
 
 You can specify the server address to listen on when you construct a server.

--- a/content/icerpc/protocols-and-transports/icerpc-multiplexed-transports.md
+++ b/content/icerpc/protocols-and-transports/icerpc-multiplexed-transports.md
@@ -118,20 +118,22 @@ classDiagram
     DuplexConnection <|-- TcpConnection
 ```
 
-In C#, the default multiplexed transport is Slic over TCP and is called `tcp`. The following statements all create
-equivalent icerpc connections.
+In C#, the default multiplexed transport is QUIC. To run icerpc over Slic-over-TCP instead, set the transport
+to `tcp` in the server address:
 
 ```csharp
-// Create a client connection with the default multiplexed client transport, Slic over TCP.
-using await var clientConnection = new ClientConnection("icerpc://hello.zeroc.com");
+// Select Slic over TCP with the transport parameter.
+await using var clientConnection = new ClientConnection("icerpc://hello.zeroc.com?transport=tcp");
+```
 
-// Make sure we use Slic over TCP (correct but redundant).
-using await var clientConnection = new ClientConnection("icerpc://hello.zeroc.com?transport=tcp");
+You can also create the Slic-over-TCP transport explicitly and pass it to the connection—for instance, to
+configure Slic or TCP options:
 
-// Create a new multiplexed client transport with default options.
+```csharp
+// Create a multiplexed client transport (Slic over TCP) with default options.
 var clientTransport = new SlicClientTransport(new TcpClientTransport());
-using await var clientConnection = new ClientConnection(
-    "icerpc://hello.zeroc.com",
+await using var clientConnection = new ClientConnection(
+    "icerpc://hello.zeroc.com?transport=tcp",
     multiplexedClientTransport: clientTransport);
 ```
 


### PR DESCRIPTION
## Summary

In 0.6, **QUIC is the default multiplexed transport**, but several reference pages in the `connection/` and `protocols-and-transports/` chapters still described Slic-over-TCP as the default — directly contradicting the (correct) tutorials. These were the only outright *factual* errors found in the 0.6 docs review and are release blockers.

## Changes

- **`icerpc-multiplexed-transports.md`** — state that the default is QUIC; show that Slic-over-TCP is selected with `?transport=tcp` (dropped the "correct but redundant" framing, which is now backwards). Also fixed the pre-existing `using await var` → `await using var` syntax typos in the samples.
- **`security-with-tls.md`** — make the `tcp` example explicit with `?transport=tcp` so it actually demonstrates plain TCP (a bare `icerpc://…` URI now resolves to QUIC + TLS). Modernized the `quic` server-certificate example to `X509CertificateLoader.LoadPkcs12FromFile` + `ServerCertificateContext` (matching the 0.6 release notes; the `X509Certificate2(string)` constructor is obsolete). Fixed the coloc example's missing comma.
- **`server-address.md`** — note that an omitted `transport` resolves to QUIC, with `?transport=tcp` for Slic over TCP.

Part of a 3-PR series addressing the 0.6.0 docs review. This is PR 1/3 (blockers).