### PR TITLE
Document 0.6 installation, packaging, and supported platforms

### DIFF
--- a/content/getting-started/installation/existing-project.md
+++ b/content/getting-started/installation/existing-project.md
@@ -40,6 +40,24 @@ that depends on the `Google.Protobuf` and `IceRpc.Protobuf` packages. You need `
 development.
 {% /callout %}
 
+## IceRPC and Ice packages
+
+If you plan on using IceRPC to communicate with [Ice] applications—or to compile Ice's Slice (`.ice`) files
+directly—add the [IceRpc.Ice] and [ZeroC.Ice.Slice.Tools] packages to your project with the following commands:
+
+```shell {% showTitle=false %}
+dotnet add package IceRpc.Ice
+dotnet add package ZeroC.Ice.Slice.Tools
+```
+
+Adding [IceRpc.Ice] automatically pulls its dependencies, including the [IceRpc] package.
+
+{% callout %}
+[ZeroC.Ice.Slice.Tools] is an Ice package that provides the `slice2cs` compiler and the `SliceCompile` task. The code it
+generates from your `.ice` files depends on the `IceRpc.Ice` package. You need `ZeroC.Ice.Slice.Tools` only during
+development. See [Mapping Ice to C# with IceRPC][ice-mapping] for the project-file setup.
+{% /callout %}
+
 ## IceRPC only
 
 If you plan on using IceRPC with JSON, or some other serialization format, add the [IceRpc] package to your project with
@@ -60,8 +78,41 @@ dotnet add package IceRpc.Logger
 
 The full list of IceRPC packages is available on the [next page][full-list].
 
+## Build telemetry
+
+The Slice and Protobuf toolchains—[IceRpc.Slice.Tools] and [IceRpc.Protobuf.Tools]—collect anonymous build telemetry by
+default. During the compilation of your Slice or Protobuf files, a build plug-in sends anonymous data over a secure
+connection to the IceRPC build telemetry server. This data includes, for example:
+
+- The versions of the compiler and code generators.
+- The operating system, version, and platform architecture.
+- The .NET SDK version used by the build.
+- Whether the build ran in a continuous integration (CI) environment.
+- Counts of the interfaces/services, operations/RPCs, and types/messages in the compilation.
+
+The IceRPC team uses this data to understand how the tools are used and to prioritize future development; it is stored in
+a private database and not shared with any third parties.
+
+To opt out, set the `IceRpcBuildTelemetry` property to `false` in your project file:
+
+```xml
+<PropertyGroup>
+  <IceRpcBuildTelemetry>false</IceRpcBuildTelemetry>
+</PropertyGroup>
+```
+
+This suppresses all telemetry collection by removing the build telemetry plug-in from the compilation pipeline. For the
+exact data collected by each toolchain, see the [IceRpc.Slice.Tools][slice-tools-readme] and
+[IceRpc.Protobuf.Tools][protobuf-tools-readme] READMEs.
+
 [full-list]: nuget-packages
+[slice-tools-readme]: https://github.com/icerpc/icerpc-csharp/tree/0.6.x/src/IceRpc.Slice.Tools/README.md
+[protobuf-tools-readme]: https://github.com/icerpc/icerpc-csharp/tree/0.6.x/src/IceRpc.Protobuf.Tools/README.md
+[ice-mapping]: /icerpc-for-ice-users/ice-definitions/language-mapping
 [IceRpc.Logger]: https://www.nuget.org/packages/IceRpc.Logger
+[IceRpc.Ice]: https://www.nuget.org/packages/IceRpc.Ice
+[ZeroC.Ice.Slice.Tools]: https://www.nuget.org/packages/ZeroC.Ice.Slice.Tools
+[Ice]: /icerpc-for-ice-users
 [Google.Protobuf]: https://www.nuget.org/packages/Google.Protobuf
 [IceRpc.Protobuf.Tools]: https://www.nuget.org/packages/IceRpc.Protobuf.Tools
 [IceRpc.Protobuf]: https://www.nuget.org/packages/IceRpc.Protobuf

--- a/content/getting-started/installation/existing-project.md
+++ b/content/getting-started/installation/existing-project.md
@@ -82,7 +82,7 @@ The full list of IceRPC packages is available on the [next page][full-list].
 
 The Slice and Protobuf toolchains—[IceRpc.Slice.Tools] and [IceRpc.Protobuf.Tools]—collect anonymous build telemetry by
 default. During the compilation of your Slice or Protobuf files, a build plug-in sends anonymous data over a secure
-connection to the IceRPC build telemetry server. This data includes, for example:
+connection to the IceRPC build telemetry server. This data includes:
 
 - The versions of the compiler and code generators.
 - The operating system, version, and platform architecture.

--- a/content/getting-started/installation/nuget-packages.md
+++ b/content/getting-started/installation/nuget-packages.md
@@ -19,7 +19,7 @@ description: A list of all the IceRPC NuGet packages
 | [IceRpc.Retry]                          | Retry interceptor                                                                       |
 | [IceRpc.ServiceGenerator]               | C# source generator enabled by the `[Service]` attribute.                               |
 | [IceRpc.Slice]                          | IceRPC + Slice integration library                                                      |
-| [IceRpc.Slice.Tools]                    | Slice compiler slicec, the C# code generators, and MSBuild support                      |
+| [IceRpc.Slice.Tools]                    | Slice compiler (`slicec`), the C# code generators, and MSBuild support                  |
 | [IceRpc.Telemetry]                      | OpenTelemetry interceptor and middleware                                                |
 | [IceRpc.Templates]                      | Project templates for IceRPC                                                            |
 | [IceRpc.Transports.Coloc]               | Coloc duplex transport                                                                  |

--- a/content/getting-started/installation/nuget-packages.md
+++ b/content/getting-started/installation/nuget-packages.md
@@ -19,7 +19,7 @@ description: A list of all the IceRPC NuGet packages
 | [IceRpc.Retry]                          | Retry interceptor                                                                       |
 | [IceRpc.ServiceGenerator]               | C# source generator enabled by the `[Service]` attribute.                               |
 | [IceRpc.Slice]                          | IceRPC + Slice integration library                                                      |
-| [IceRpc.Slice.Tools]                    | Slice compiler, code generators for C#, and MSBuild support                             |
+| [IceRpc.Slice.Tools]                    | Slice compiler slicec, the C# code generators, and MSBuild support                      |
 | [IceRpc.Telemetry]                      | OpenTelemetry interceptor and middleware                                                |
 | [IceRpc.Templates]                      | Project templates for IceRPC                                                            |
 | [IceRpc.Transports.Coloc]               | Coloc duplex transport                                                                  |

--- a/content/icerpc-for-ice-users/ice-definitions/language-mapping.md
+++ b/content/icerpc-for-ice-users/ice-definitions/language-mapping.md
@@ -12,19 +12,23 @@ Ice's Slice language is described in the [Ice Manual].
 
 ## Targeting IceRPC
 
-The Ice compiler for C# (`slice2cs`) allows you to generate code for IceRPC. If you build your project with MSBuild, you
-can set the `IceRpc` attribute to true:
+The Ice compiler for C# (`slice2cs`) allows you to generate code for IceRPC. If you build your project with MSBuild, add
+your `.ice` files with the `SliceCompile` item type and set its `IceRpc` attribute to true, then reference the
+[ZeroC.Ice.Slice.Tools] and [IceRpc.Ice] packages:
 
 ```xml
 <ItemGroup>
   <SliceCompile Include="../slice/Greeter.ice" IceRpc="true" />
+  <PackageReference Include="ZeroC.Ice.Slice.Tools" PrivateAssets="All" />
+  <PackageReference Include="IceRpc.Ice" />
 </ItemGroup>
 ```
 
-or
+Instead of setting `IceRpc="true"` on each `SliceCompile` item, you can make icerpc the default RPC framework for all
+`.ice` files in your project:
 
 ```xml
-  <!-- Set the default RPC framework for .ice file compilation to icerpc -->
+<!-- Set the default RPC framework for .ice file compilation to icerpc -->
 <ItemDefinitionGroup>
   <SliceCompile>
     <IceRpc>true</IceRpc>
@@ -35,7 +39,10 @@ or
 In IceRPC mode, `slice2cs` generates C# files with the extension `.IceRpc.cs`.
 
 {% callout %}
-The [ZeroC.Ice.Slice.Tools] NuGet package provides the `slice2cs` compiler and the `SliceCompile` task.
+The [ZeroC.Ice.Slice.Tools] NuGet package provides the `slice2cs` compiler and the `SliceCompile` task; it is a
+build-time-only dependency, hence `PrivateAssets="All"`. The [IceRpc.Ice] package provides the runtime integration
+between IceRPC's core APIs and the generated `.IceRpc.cs` code—without it, the generated integration code does not
+compile.
 {% /callout %}
 
 ## C# language mapping
@@ -58,3 +65,4 @@ There are a few notable differences between the original C# mapping (when target
 [Ice Manual]: https://docs.zeroc.com/ice/3.8/csharp/the-slice-language
 [Slice]: /slice
 [ZeroC.Ice.Slice.Tools]: https://www.nuget.org/packages/ZeroC.Ice.Slice.Tools
+[IceRpc.Ice]: https://www.nuget.org/packages/IceRpc.Ice

--- a/content/icerpc-for-ice-users/ice-definitions/language-mapping.md
+++ b/content/icerpc-for-ice-users/ice-definitions/language-mapping.md
@@ -24,11 +24,11 @@ your `.ice` files with the `SliceCompile` item type and set its `IceRpc` attribu
 </ItemGroup>
 ```
 
-Instead of setting `IceRpc="true"` on each `SliceCompile` item, you can make icerpc the default RPC framework for all
+Instead of setting `IceRpc="true"` on each `SliceCompile` item, you can make IceRPC the default RPC framework for all
 `.ice` files in your project:
 
 ```xml
-<!-- Set the default RPC framework for .ice file compilation to icerpc -->
+<!-- Set the default RPC framework for .ice file compilation to IceRPC -->
 <ItemDefinitionGroup>
   <SliceCompile>
     <IceRpc>true</IceRpc>


### PR DESCRIPTION
## Summary

Fills the under-documented "new in 0.6" installation/packaging gaps found in the docs review.

## Changes

- **`existing-project.md`**
  - New **IceRPC and Ice packages** section for the `.ice` / Ice-interop path (`IceRpc.Ice` + `ZeroC.Ice.Slice.Tools`), mirroring the existing Slice/Protobuf sections.
  - New **Build telemetry** section: 0.6 turns on anonymous build telemetry **by default** for the Slice and Protobuf toolchains; documents what's collected and the `<IceRpcBuildTelemetry>false</IceRpcBuildTelemetry>` opt-out, with links to the tooling READMEs.
- **`language-mapping.md`** — the `.ice` project-file example was missing the required `IceRpc.Ice` package (without it the generated `*.IceRpc.cs` code doesn't compile) and `PrivateAssets="All"` on the tools package. Completed it to match the canonical `examples/ice/Greeter` csproj, and explained both packages.
- **`nuget-packages.md`** — updated the `IceRpc.Slice.Tools` description to reflect the new architecture (`slicec` compiler driving C# generator plug-ins) instead of implying a monolithic compiler.

Part of a 3-PR series addressing the 0.6.0 docs review. This is PR 2/3 (important gaps).

> The 0.6 supported-platforms page is now owned by #497, so it is no longer part of this PR.
