### PR TITLE
Mention new 0.6 APIs and behaviors in reference pages

### DIFF
--- a/content/icerpc/dispatch/router.md
+++ b/content/icerpc/dispatch/router.md
@@ -36,6 +36,14 @@ These other dispatchers are registered with the router using `map` and `mount` m
     router.Map("/greeter", chatbot);
     ```
 
+    A Slice or Protobuf-generated service has a default service path. You can map such a service at this default path
+    with the `Map` overload that takes only the service:
+
+    ```csharp
+    var router = new Router();
+    router.Map(new Chatbot()); // maps Chatbot at its default service path, e.g. /VisitorCenter.Greeter
+    ```
+
 - `mount` associates a dispatcher with a path prefix in the router.
 
     For example, you can mount path-prefix `/user` to an account service. A request with path `/user` or

--- a/content/icerpc/invocation/outgoing-request.md
+++ b/content/icerpc/invocation/outgoing-request.md
@@ -18,6 +18,10 @@ An outgoing request carries all the information an invoker needs to send a reque
 An outgoing request also holds [features](#request-features). These features are used for local communications within
 this pipeline; they are also used for communications between invokers in the pipeline and your application code.
 
+By default, an outgoing request is two-way—the invoker sends the request and awaits a response. You can make a request
+one-way by setting its [IsOneway] property to `true`; a one-way request carries no response, so the invocation completes
+once the request has been sent.
+
 ## Request fields
 
 The request fields represent out-of-band information carried by a request "over the wire". These fields are usually read
@@ -102,3 +106,4 @@ only request features: since it's all local, there is no need for response featu
 
 [IFeatureCollection]: csharp:IceRpc.Features.FeatureCollection
 [ICompressFeature]: csharp:IceRpc.Features.ICompressFeature
+[IsOneway]: csharp:IceRpc.OutgoingRequest#IceRpc_OutgoingRequest_IsOneway

--- a/content/protobuf/encoding.md
+++ b/content/protobuf/encoding.md
@@ -20,5 +20,9 @@ is encoded as a Length-Prefixed-Message inside a request or response payload:
 It's a simple and uniform framing. IceRPC + Protobuf does not currently provide support for gRPC-style compression
 (`Compress-Flag` set to 1) so `Compress-Flag` is always set to 0.
 
+As a special case, a one-way call produces a response with an empty payload—zero bytes, carrying no
+Length-Prefixed-Message. IceRPC + Protobuf accepts such an empty response payload and decodes it as a
+default-constructed response message.
+
 [gRPC protocol]: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
 [Protocol Buffers Encoding]: https://protobuf.dev/programming-guides/encoding/

--- a/content/protobuf/index.md
+++ b/content/protobuf/index.md
@@ -11,7 +11,8 @@ created by Google and available for many programming languages. [Protobuf] is th
 frameworks.
 
 This chapter describes the IceRPC + Protobuf integration, not Protobuf itself. The IceRPC + Protobuf integration uses
-standard Protobuf files, with the regular Protobuf syntax and semantics.
+standard Protobuf files, with the regular Protobuf syntax and semantics; it supports proto2, proto3, and
+[Protobuf editions].
 
 ## The IceRPC + Protobuf integration
 
@@ -117,4 +118,5 @@ public partial interface IGreeterService
 
 [gRPC]: https://grpc.io/
 [Interface Definition Language]: https://en.wikipedia.org/wiki/Interface_description_language
+[Protobuf editions]: https://protobuf.dev/editions/overview/
 [Protobuf]: https://en.wikipedia.org/wiki/Protocol_Buffers


### PR DESCRIPTION
## Summary

Small additions covering 0.6 APIs/behaviors that the reference pages don't yet mention (the "minor / polish" bucket of the docs review).

## Changes

- **`slice/basics/slice-components.md`** — name `IceRpc.Slice.Generator` as the IceRPC-specific code generator, parallel to the existing `ZeroC.Slice.Generator` description.
- **`icerpc/dispatch/router.md`** — document the `Map(service)` overload that maps a Slice/Protobuf-generated service at its default service path (`router.Map(new Chatbot())`).
- **`icerpc/invocation/outgoing-request.md`** — document two-way vs one-way requests and the `OutgoingRequest.IsOneway` get-set property (new in 0.6).
- **`protobuf/index.md`** — note that the integration supports Protobuf editions.
- **`protobuf/encoding.md`** — note that a one-way call's empty response payload is accepted and decoded as a default-constructed message.

Part of a 3-PR series addressing the 0.6.0 docs review. This is PR 3/3 (polish).