### PR TITLE
Add Sonoma to cspell and run spellcheck on pushes to main

### DIFF
--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -1,6 +1,8 @@
 name: 'Check spelling'
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -59,6 +59,7 @@
     "Slic",
     "slicec",
     "smoothstep",
+    "Sonoma",
     "Structs",
     "tailwindcss",
     "TIMEOFDAY",


### PR DESCRIPTION
The spellcheck job started failing on PRs #515 and #516 with `Unknown word (Sonoma)` in the supported-platforms pages for icerpc-csharp 0.2–0.4, which list macOS 14 (Sonoma). The word has been in those pages since 2023/2024 and used to pass — a newer cspell (bundled when we bumped cspell-action to v8) dropped "Sonoma" from the en_US dictionary, so this adds it to the project word list in .vscode/cspell.json.

The job also only ran on `pull_request`, so pushes and merges to main were never spellchecked directly. This adds a `push` trigger for main so those commits are checked too.

Verified locally against the exact CI globs: 210 files checked, 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)