### PR TITLE
Invalidate CloudFront cache on deploy to avoid serving stale HTML

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,22 @@ jobs:
             docker compose pull icerpc-docs
             docker compose up -d icerpc-docs
 
+      - name: Invalidate CloudFront cache
+        # Next.js serves prerendered pages with `Cache-Control: s-maxage=31536000`,
+        # so CloudFront caches each HTML page for up to a year. This deploy replaces
+        # the container along with its content-hashed /_next/static chunks, so a
+        # stale cached page would keep referencing chunk files the new build no
+        # longer has — a 404 that breaks hydration (e.g. the top-nav search stops
+        # working). Purge the edge cache so pages are re-fetched with the new
+        # build's asset URLs. Immutable /_next/static assets are unaffected.
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+          DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+        run: |
+          aws cloudfront create-invalidation --distribution-id "$DISTRIBUTION_ID" --paths '/*'
+
   cleanup:
     name: Cleanup old images
     needs: publish


### PR DESCRIPTION
Adds a CloudFront invalidation step to the deploy job so a release can't leave stale HTML in the CDN.

The homepage search bar recently broke because CloudFront was serving a ~9-day-old cached copy of `/` whose HTML referenced a content-hashed `/_next/static` chunk that a later deploy had already removed. The browser 404'd on that chunk, the page never finished hydrating, and the shared top-nav DocSearch button went dead — no ⌘K keys, and clicking did nothing — while other pages, whose cached HTML happened to reference chunks that still existed, kept working. Next.js serves prerendered pages with `Cache-Control: s-maxage=31536000`, so without a purge on deploy CloudFront can keep serving a page for up to a year after its assets are gone.

Because we deploy by swapping the container (which discards the previous build's chunks), the fix is to purge the edge cache once the new container is up. The content-hashed `/_next/static` assets are immutable and unaffected; only the HTML documents need refreshing.

- **New step** runs `aws cloudfront create-invalidation --paths '/*'` right after `docker compose up -d` (the AWS CLI is preinstalled on the runner, so there's no new action to SHA-pin).
- **Requires three new repo secrets**: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `CLOUDFRONT_DISTRIBUTION_ID`, backed by an IAM identity allowed to `cloudfront:CreateInvalidation` on the distribution. If you'd prefer GitHub OIDC over static keys, I can switch it to a role-assume step instead.
