### PR TITLE
Fix broken code samples in docs content

### DIFF
--- a/content/getting-started/icerpc-protobuf-tutorial/client-tutorial.md
+++ b/content/getting-started/icerpc-protobuf-tutorial/client-tutorial.md
@@ -137,6 +137,8 @@ Finally, the client sends a `Greet` request, awaits the response (the greeting),
 prints the greeting and shuts down the connection gracefully:
 
 ```csharp
+var request = new GreetRequest { Name = Environment.UserName };
+
 GreetResponse response = await greeter.GreetAsync(request);
 
 Console.WriteLine(response.Greeting);

--- a/content/icerpc-for-ice-users/ice-definitions/enum-types.md
+++ b/content/icerpc-for-ice-users/ice-definitions/enum-types.md
@@ -13,7 +13,7 @@ enum Fruit { Apple, Pear, Orange }
 ```
 
 ```csharp
-enum Fruit { Apple, Pear, Orange }
+public enum Fruit { Apple, Pear, Orange }
 ```
 
 {% /aside %}

--- a/content/icerpc-for-ice-users/ice-definitions/fields.md
+++ b/content/icerpc-for-ice-users/ice-definitions/fields.md
@@ -23,7 +23,7 @@ struct Person
 maps to:
 
 ```csharp
-public record struct Person
+public partial record struct Person
 {
     public required string Name { get; set; } // Ice string maps to C# string
     public Address? Address { get; set; }     // Ice Address maps to nullable C# Address
@@ -84,7 +84,7 @@ struct Location
 maps to:
 
 ```csharp
-public record struct Location
+public partial record struct Location
 {
     public required string Name { get; set; }
     public Point Point { get; set; }

--- a/content/icerpc/connection/security-with-tls.md
+++ b/content/icerpc/connection/security-with-tls.md
@@ -21,7 +21,7 @@ For example:
 ```csharp
 // Always uses TLS.
 await using var connection = new ClientConnection(
-    "icerpc://hello.zeroc.com",
+    new Uri("icerpc://hello.zeroc.com"),
     multiplexedClientTransport: new QuicClientTransport());
 ```
 
@@ -59,11 +59,11 @@ In C#, this client-side TLS configuration is provided by a [SslClientAuthenticat
 ```csharp
 // We select the tcp transport (Slic over TCP) with ?transport=tcp, since the default transport is quic.
 // This connection does not use TLS since we don't pass a SslClientAuthenticationOptions parameter.
-await using var plainTcpConnection = new ClientConnection("icerpc://hello.zeroc.com?transport=tcp");
+await using var plainTcpConnection = new ClientConnection(new Uri("icerpc://hello.zeroc.com?transport=tcp"));
 
 // We pass a non-null SslClientAuthenticationOptions so the connection uses TLS.
 await using var secureTcpConnection = new ClientConnection(
-    "icerpc://hello.zeroc.com?transport=tcp",
+    new Uri("icerpc://hello.zeroc.com?transport=tcp"),
     new SslClientAuthenticationOptions());
 ```
 
@@ -81,14 +81,14 @@ For example:
 
 ```csharp
 // Uses the default client transport, TcpClientTransport.
-await using var connection = new ClientConnection("ice://hello.zeroc.com?transport=ssl");
+await using var connection = new ClientConnection(new Uri("ice://hello.zeroc.com?transport=ssl"));
 ```
 
 is equivalent to:
 
 ```csharp
 await using var connection = new ClientConnection(
-    "ice://hello.zeroc.com?transport=tcp",
+    new Uri("ice://hello.zeroc.com?transport=tcp"),
     new SslClientAuthenticationOptions());
 ```
 
@@ -113,7 +113,7 @@ get an error.
 ```csharp
 // Does not work: can't get a TLS connection with a transport that doesn't support TLS.
 await using var connection = new ClientConnection(
-    "icerpc://colochost",
+    new Uri("icerpc://colochost"),
     new SslClientAuthenticationOptions(),
     multiplexedClientTransport: new SlicClientTransport(colocClientTransport));
 ```

--- a/content/icerpc/connection/server-address.md
+++ b/content/icerpc/connection/server-address.md
@@ -67,7 +67,7 @@ using IceRpc;
 
 await using var server = new Server(..., new Uri("icerpc://[::1]:0"));
 ServerAddress actualServerAddress = server.Listen();
-Console.WriteLine($"server is now listening on {actualServerAddress}); // shows actual port
+Console.WriteLine($"server is now listening on {actualServerAddress}"); // shows actual port
 // then somehow share this server address with the clients
 ```
 

--- a/content/icerpc/dependency-injection/dispatch-pipeline-with-di.md
+++ b/content/icerpc/dependency-injection/dispatch-pipeline-with-di.md
@@ -154,6 +154,7 @@ public class DIDeadlineMiddleware : IMiddleware<DeadlineInformation>
             deadlineInfo.Value = deadline;
 
             // TODO: enforce deadline while calling _next.DispatchAsync.
+            return _next.DispatchAsync(request, cancellationToken);
         }
         else
         {

--- a/content/icerpc/dependency-injection/invocation-pipeline-with-di.md
+++ b/content/icerpc/dependency-injection/invocation-pipeline-with-di.md
@@ -31,7 +31,7 @@ using Microsoft.Extensions.DependencyInjection;
 // Add a new IInvoker singleton configured with an action.
 services
     .AddIceRpcClientConnection()
-    .AddIceRpcInvoker(builder => builder.Into<ClientConnection>())
+    .AddIceRpcInvoker(builder => builder.Into<ClientConnection>());
 ```
 
 You must specify a final invoker with the `Into` method. With this example, the new invoker flows into the
@@ -60,7 +60,7 @@ services
     .AddIceRpcInvoker(builder =>
         builder
             .UseLogger()
-            .Into<ClientConnection>())
+            .Into<ClientConnection>());
 ```
 
 Here, `UseLogger` is an extension method provided by the `IceRpc.Logger` assembly. This extension method works with any

--- a/content/icerpc/dispatch/dispatch-pipeline.md
+++ b/content/icerpc/dispatch/dispatch-pipeline.md
@@ -54,7 +54,7 @@ using IceRpc;
 var clientConnectionOptions = new ClientConnectionOptions
 {
     Dispatcher = new MyCallback(),
-    ServerAddress = new Uri("icerpc://hello.zeroc.com")
+    ServerAddress = new ServerAddress(new Uri("icerpc://hello.zeroc.com"))
 };
 
 await using var connection = new ClientConnection(clientConnectionOptions);

--- a/content/icerpc/dispatch/incoming-request.md
+++ b/content/icerpc/dispatch/incoming-request.md
@@ -34,9 +34,9 @@ information middleware, it sets the [IDispatchInformationFeature] and you can re
 
 ```csharp
 // In Slice service implementation
-public ValueTask OpAsync(string message, FeatureCollection features, CancellationToken cancellationToken)
+public ValueTask OpAsync(string message, IFeatureCollection features, CancellationToken cancellationToken)
 {
-    if (features.Get<IDispatchInformationFeature> is IDispatchInformationFeature dispatchInformation)
+    if (features.Get<IDispatchInformationFeature>() is IDispatchInformationFeature dispatchInformation)
     {
         EndPoint from = dispatchInformation.ConnectionContext.TransportConnectionInformation.RemoteNetworkAddress;
         Console.WriteLine($"dispatching request from {from}");

--- a/content/icerpc/invocation/service-address.md
+++ b/content/icerpc/invocation/service-address.md
@@ -102,7 +102,7 @@ await using var clientConnection = new ClientConnection(new Uri("icerpc://hello.
 using var request = new OutgoingRequest(new ServiceAddress(new Uri("icerpc:/greeter")));
 
 // ClientConnection accepts requests that don't specify a server address
-IncomingResponse response = await connection.InvokeAsync(request);
+IncomingResponse response = await clientConnection.InvokeAsync(request);
 ```
 
 ## Relative service address

--- a/content/protobuf/index.md
+++ b/content/protobuf/index.md
@@ -66,7 +66,7 @@ namespace VisitorCenter;
 public partial interface IGreeter
 {
    Task<GreetResponse> GreetAsync(
-      GreeterRequest message,
+      GreetRequest message,
       IFeatureCollection? features = null,
       CancellationToken cancellationToken = default);
 }

--- a/content/protobuf/language-mapping/service.md
+++ b/content/protobuf/language-mapping/service.md
@@ -63,7 +63,7 @@ option csharp_namespace = "Example";
 
 service Widget {
     rpc Spin (SpinConfig)
-        returns (google.protobuf.Empty)
+        returns (google.protobuf.Empty);
 }
 ```
 

--- a/content/slice/basics/contract-first.md
+++ b/content/slice/basics/contract-first.md
@@ -125,7 +125,7 @@ await using var connection = new ClientConnection(new Uri("icerpc://examples.zer
 var greeterProxy = new GreeterProxy(connection, new Uri("icerpc:/greeter"));
 
 // Make an RPC and print the return value.
-string greeting = await greeter.GreetAsync("Syd");
+string greeting = await greeterProxy.GreetAsync("Syd");
 Console.WriteLine(greeting);
 ```
 

--- a/content/slice/language-guide/dictionary-types.md
+++ b/content/slice/language-guide/dictionary-types.md
@@ -57,11 +57,11 @@ struct DictionaryExample {
 ```csharp
 internal partial record struct DictionaryExample
 {
-    internal IDictionary<
+    internal required IDictionary<
         int,
-        IDictionary<string, double>> X;
+        IDictionary<string, double>> X { get; set; }
 
-    internal IDictionary<string, double?> Y;
+    internal required IDictionary<string, double?> Y { get; set; }
 }
 ```
 

--- a/content/slice/language-guide/fields.md
+++ b/content/slice/language-guide/fields.md
@@ -10,7 +10,7 @@ A field is defined as `name: Type`, where `name` is the field's name, and `Type`
 ```slice
 name: string
 image: Sequence<uint8>
-address: WellKnownType::Uri
+address: WellKnownTypes::Uri
 ```
 
 Fields can be separated by either whitespace or a single comma. You would typically use a comma when fields are on the

--- a/content/slice/language-guide/interface.md
+++ b/content/slice/language-guide/interface.md
@@ -197,11 +197,11 @@ initialize the invoker, for example:
 var proxy = new WidgetProxy { Invoker = connection };
 
 // The above is equivalent to:
-var proxy = new WidgetPRoxy(connection);
+var proxy = new WidgetProxy(connection);
 ```
 
-When a Slice interface derives from another interface, its proxy struct provides an implicit conversion operator to be
-base interface. For example:
+When a Slice interface derives from another interface, its proxy struct provides an implicit conversion operator to the
+base interface's proxy struct. For example:
 
 ```slice
 module Draw
@@ -218,12 +218,12 @@ namespace Draw;
 
 internal readonly partial record struct RectangleProxy : IRectangle, IProxy
 {
-    internal static implicit operator ShapeProxy(RectangleProxy proxy)
+    public static implicit operator ShapeProxy(RectangleProxy proxy)
     {
         ...
     }
 
-    internal static implicit operator FillableProxy(RectangleProxy proxy)
+    public static implicit operator FillableProxy(RectangleProxy proxy)
     {
         ...
     }

--- a/content/slice/language-guide/result-types.md
+++ b/content/slice/language-guide/result-types.md
@@ -49,7 +49,7 @@ The Slice type parameters are mapped to C# type parameters, following the usual 
 | Slice                                      | C# mapping                          |
 |--------------------------------------------|-------------------------------------|
 | `Result<string, int32>`                    | `Result<string, int>`               |
-| `Result<WellknownTypes::TimeStamp, int32>` | `Result<DateTime, int>`             |
+| `Result<WellKnownTypes::TimeStamp, int32>` | `Result<DateTime, int>`             |
 | `Result<string?, varint32>`                | `Result<string?, int>`              |
 | `Result<MyStruct, MyEnum>`                 | `Result<MyStruct, MyEnum>`          |
 

--- a/content/slice/language-guide/sequence-types.md
+++ b/content/slice/language-guide/sequence-types.md
@@ -52,9 +52,9 @@ struct SequenceExample {
 ```csharp
 internal partial record struct SequenceExample
 {
-    internal IList<IList<string>> X;
+    internal required IList<IList<string>> X { get; set; }
 
-    internal IList<int?> Y;
+    internal required IList<int?> Y { get; set; }
 }
 ```
 

--- a/content/slice/language-guide/using-proxies-as-slice-types.md
+++ b/content/slice/language-guide/using-proxies-as-slice-types.md
@@ -31,7 +31,7 @@ interface Widget {
 }
 
 interface WidgetFactory {
-    /// Creates a new @Widget and returns its service address.
+    /// Creates a new {@link Widget} and returns its service address.
     createWidget() -> IceRpc::ServiceAddress
 }
 ```
@@ -62,7 +62,7 @@ interface Widget {
 }
 
 interface WidgetFactory {
-    /// Creates a new @Widget and returns a proxy to this new Widget.
+    /// Creates a new {@link Widget} and returns a proxy to this new Widget.
     createWidget() -> WidgetProxy
 }
 


### PR DESCRIPTION
Fixes 31 defects in code samples across 19 content pages, found during a full editorial review. Every fix was verified against the `0.6.x` branch of icerpc-csharp (examples, templates, and generator sources) — see the verification comment below.

**Doesn't compile**
- `new ClientConnection("icerpc://…")` with a plain string in six samples on the security-with-tls page — no such constructor; wrapped in `new Uri(…)`
- `ServerAddress = new Uri(…)` — the property is `ServerAddress?` → `new ServerAddress(new Uri(…))`
- service method taking `FeatureCollection` instead of `IFeatureCollection`, plus `features.Get<T>` missing its call parentheses
- unterminated interpolated string in the server-address sample
- `if` branch with no return in the DI deadline middleware (CS0161)
- `internal static implicit operator` — conversion operators must be public (CS0558)
- missing statement semicolons (invocation-pipeline-with-di ×2, a .proto snippet)

**Wrong identifiers**
- `greeter` → `greeterProxy`, `connection` → `clientConnection`, `GreeterRequest` → `GreetRequest`, `WidgetPRoxy` → `WidgetProxy`, `WellknownTypes`/`WellKnownType` → `WellKnownTypes`

**Doesn't match the documented mapping / templates**
- dictionary/sequence mapping samples showed bare C# fields; the generator emits `required … { get; set; }` properties (per fields.md)
- the Protobuf client tutorial used `request` without defining it — added the template's `var request = new GreetRequest { Name = Environment.UserName };`
- `@Widget` doc-comment links → `{@link Widget}`
- missing `public`/`partial` modifiers in two ice-users samples
- also rewords the sentence attached to the conversion-operator fix ("to be base interface" → "to the base interface's proxy struct")

🤖 Generated with [Claude Code](https://claude.com/claude-code)