### PR TITLE
Add missing frontmatter descriptions

### DIFF
--- a/content/getting-started/icerpc-protobuf-tutorial/client-tutorial.md
+++ b/content/getting-started/icerpc-protobuf-tutorial/client-tutorial.md
@@ -1,5 +1,6 @@
 ---
 title: Writing your first IceRPC + Protobuf client in C#
+description: Learn how to write your first IceRPC + Protobuf client.
 ---
 
 This tutorial is the second part of a two part series that shows how to create a

--- a/content/getting-started/icerpc-protobuf-tutorial/server-tutorial.md
+++ b/content/getting-started/icerpc-protobuf-tutorial/server-tutorial.md
@@ -1,5 +1,6 @@
 ---
 title: Writing your first IceRPC + Protobuf server in C#
+description: Learn how to write your first IceRPC + Protobuf server.
 ---
 
 This tutorial is the first part of a two part series that shows how to create a

--- a/content/getting-started/icerpc-slice-tutorial/client-tutorial.md
+++ b/content/getting-started/icerpc-slice-tutorial/client-tutorial.md
@@ -1,5 +1,6 @@
 ---
 title: Writing your first IceRPC + Slice client in C#
+description: Learn how to write your first IceRPC + Slice client.
 ---
 
 This tutorial is the second part of a two part series that shows how to create a

--- a/content/getting-started/icerpc-slice-tutorial/server-tutorial.md
+++ b/content/getting-started/icerpc-slice-tutorial/server-tutorial.md
@@ -1,5 +1,6 @@
 ---
 title: Writing your first IceRPC + Slice server in C#
+description: Learn how to write your first IceRPC + Slice server.
 ---
 
 This tutorial is the first part of a two part series that shows how to create a

--- a/content/getting-started/installation/existing-project.md
+++ b/content/getting-started/installation/existing-project.md
@@ -1,5 +1,6 @@
 ---
 title: Adding IceRPC to an existing project
+description: Learn how to get IceRPC set up in your existing project.
 ---
 
 IceRPC for C# is distributed as [NuGet] packages. To add IceRPC to an existing C# project, just add one or more

--- a/content/getting-started/installation/template.md
+++ b/content/getting-started/installation/template.md
@@ -1,5 +1,6 @@
 ---
 title: Using the IceRPC .NET project templates
+description: Start a new project using an IceRPC project template.
 ---
 
 ## Template installation

--- a/content/getting-started/supported-platforms/icerpc-csharp-0_1.md
+++ b/content/getting-started/supported-platforms/icerpc-csharp-0_1.md
@@ -1,5 +1,6 @@
 ---
 title: IceRPC for C# 0.1
+description: The supported platforms for IceRPC for C# 0.1.
 showNavigation: false
 ---
 

--- a/content/getting-started/supported-platforms/icerpc-csharp-0_2.md
+++ b/content/getting-started/supported-platforms/icerpc-csharp-0_2.md
@@ -1,5 +1,6 @@
 ---
 title: IceRPC for C# 0.2
+description: The supported platforms for IceRPC for C# 0.2.
 ---
 
 ZeroC supports IceRPC for C# on the following platforms:

--- a/content/getting-started/supported-platforms/icerpc-csharp-0_3.md
+++ b/content/getting-started/supported-platforms/icerpc-csharp-0_3.md
@@ -1,5 +1,6 @@
 ---
 title: IceRPC for C# 0.3
+description: The supported platforms for IceRPC for C# 0.3.
 ---
 
 ZeroC supports IceRPC for C# on the following platforms:

--- a/content/getting-started/supported-platforms/icerpc-csharp-0_4.md
+++ b/content/getting-started/supported-platforms/icerpc-csharp-0_4.md
@@ -1,5 +1,6 @@
 ---
 title: IceRPC for C# 0.4
+description: The supported platforms for IceRPC for C# 0.4.
 ---
 
 ZeroC supports IceRPC for C# on the following platforms:

--- a/content/getting-started/supported-platforms/icerpc-csharp-0_5.md
+++ b/content/getting-started/supported-platforms/icerpc-csharp-0_5.md
@@ -1,5 +1,6 @@
 ---
 title: IceRPC for C# 0.5
+description: The supported platforms for IceRPC for C# 0.5.
 ---
 
 ZeroC supports IceRPC for C# on the following platforms:

--- a/content/getting-started/supported-platforms/icerpc-csharp-0_6.md
+++ b/content/getting-started/supported-platforms/icerpc-csharp-0_6.md
@@ -1,5 +1,6 @@
 ---
 title: IceRPC for C# 0.6
+description: The supported platforms for IceRPC for C# 0.6.
 ---
 
 ZeroC supports IceRPC for C# on the following platforms:

--- a/content/icerpc-for-ice-users/high-level-comparison/ice-reinvented.md
+++ b/content/icerpc-for-ice-users/high-level-comparison/ice-reinvented.md
@@ -1,5 +1,6 @@
 ---
 title: Ice reinvented
+description: Learn how IceRPC compares to Ice.
 ---
 
 IceRPC is a brand new RPC framework, that we wrote from scratch and then rewrote several times over. It is a spiritual

--- a/content/icerpc-for-ice-users/ice-definitions/constants.md
+++ b/content/icerpc-for-ice-users/ice-definitions/constants.md
@@ -1,5 +1,6 @@
 ---
 title: Constants and literals
+description: Learn how Ice constants and literals map to C#.
 ---
 
 An Ice constant is mapped to a C# static class with the same name. The generated class contains a constant named

--- a/content/icerpc-for-ice-users/ice-definitions/language-mapping.md
+++ b/content/icerpc-for-ice-users/ice-definitions/language-mapping.md
@@ -1,5 +1,6 @@
 ---
 title: Mapping Ice to C# with IceRPC
+description: An overview of how Ice definitions are mapped to C#.
 ---
 
 IceRPC provides full support for Ice's original Slice language, with definitions stored in `.ice` files.

--- a/content/icerpc-for-ice-users/index.md
+++ b/content/icerpc-for-ice-users/index.md
@@ -1,5 +1,6 @@
 ---
 title: IceRPC for Ice users
+description: Understand how IceRPC relates to Ice and how to use IceRPC and Ice together.
 showAside: false
 showReadingTime: false
 ---

--- a/content/icerpc/slic-transport/overview.md
+++ b/content/icerpc/slic-transport/overview.md
@@ -1,5 +1,6 @@
 ---
 title: The Slic multiplexed transport
+description: An overview of the Slic multiplexed transport protocol.
 ---
 
 Slic is a [multiplexed transport][multiplexed-transport] that emulates [QUIC] while relying on a traditional duplex

--- a/content/slice/encoding/overview.md
+++ b/content/slice/encoding/overview.md
@@ -1,5 +1,6 @@
 ---
 title: The Slice encoding
+description: Learn how Slice encodes types into byte streams.
 ---
 
 ## Compact binary serialization format

--- a/content/slice/language-reference/doc-comments.md
+++ b/content/slice/language-reference/doc-comments.md
@@ -1,5 +1,6 @@
 ---
 title: Documentation comments
+description: A technical reference for Slice documentation comments.
 ---
 
 Slice comments that start with `///` are documentation (doc) comments. Slice doc comments can be attached to all Slice

--- a/content/slice/language-reference/index.md
+++ b/content/slice/language-reference/index.md
@@ -1,5 +1,6 @@
 ---
 title: Language reference
+description: A technical reference for the Slice language and its grammar notation.
 ---
 
 <!-- cspell:words ANTLR NAUR -->

--- a/content/slice/language-reference/preprocessor-directives.md
+++ b/content/slice/language-reference/preprocessor-directives.md
@@ -1,5 +1,6 @@
 ---
 title: Preprocessor directives
+description: A technical reference for the Slice preprocessor directives.
 ---
 
 The preprocessor operates on lines beginning with a `#` character (ignoring any leading whitespace). These lines

--- a/content/slice/language-reference/slice-grammar.md
+++ b/content/slice/language-reference/slice-grammar.md
@@ -1,5 +1,6 @@
 ---
 title: Slice grammar
+description: The complete lexical and syntactic grammar of the Slice language.
 ---
 
 This page describes the grammatical rules, usage, and restrictions of the Slice language.


### PR DESCRIPTION
Adds a `description:` to the 22 content pages that had none — without one, the page renders an empty `<meta name="description">` and empty OG/Twitter description, which hurts how these pages appear in search results and link previews.

The affected pages were the four tutorials, the template/existing-project installation pages, all six supported-platforms pages, the entire Slice language-reference section, the Slice encoding and Slic transport overviews, and a few icerpc-for-ice-users pages. Where a nav card already described the page (tutorials, installation, Slice encoding), the description reuses that card's copy verbatim; the rest are new one-liners written in the same style — worth a quick read since they're new user-facing copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)