### PR TITLE
Add name field to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "icerpc-docs",
       "dependencies": {
         "@docsearch/react": "^4.6.3",
         "@fortawesome/fontawesome-svg-core": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "icerpc-docs",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Adds a `name` field to package.json, plus the corresponding root-package entry npm records in the lockfile.

Without it, npm infers the project name from the checkout directory and rewrites package-lock.json's `name` whenever an install runs from a differently-named folder (git worktrees, renamed checkouts), causing spurious lockfile churn — which is how the odd name briefly appeared during #528.

🤖 Generated with [Claude Code](https://claude.com/claude-code)