### PR TITLE
Update brace-expansion to address security advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4585,9 +4585,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8087,9 +8087,9 @@
       "license": "MIT"
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Bumps the transitive `brace-expansion` copies to patched versions to clear the open Dependabot security advisory.

Dependabot couldn't apply this one itself — it proposed downgrading `eslint-config-next` from 16.2.9 to 12.0.4, having tried to collapse both `brace-expansion` trees onto a single version. That was never necessary: `minimatch@3` asks for `^1.1.7`, and the patched `1.1.18` satisfies that range fine. npm simply won't re-resolve an already-satisfied dependency, so the lockfile sat at 1.1.16 until nudged with `npm update brace-expansion`.

- **`minimatch@3.1.5` → `brace-expansion`** — 1.1.16 → 1.1.18 (the copy the advisory flagged; reached via `eslint-config-next` → `eslint-plugin-import`)
- **`minimatch@10.2.5` → `brace-expansion`** — 5.0.8 → 5.0.9 (already unaffected, picked up alongside)

Lockfile-only — no `package.json` change, no `overrides` entry, and no phantom direct dependency, matching the approach used in #528. Both copies are dev-only, reached solely through `eslint-config-next`. Verified with a clean `npm ci`: `npm audit` no longer flags `brace-expansion`, and `npm run lint` and `npm run build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
