### PR TITLE
Use npm ci in CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -14,6 +14,6 @@ jobs:
           node-version: 24.x
           cache: 'npm'
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Build
         run: npm run build --omit=dev


### PR DESCRIPTION
- Replace `npm install` with `npm ci` in the Node.js CI workflow, so builds install exactly what `package-lock.json` pins instead of resolving a fresh tree.

Left `--ignore-scripts` off deliberately: `sharp` and `unrs-resolver` need their install scripts to fetch native binaries.